### PR TITLE
Add informal statements to DH-based assumptions

### DIFF
--- a/Assumptions/Computational Diffie-Hellman.md
+++ b/Assumptions/Computational Diffie-Hellman.md
@@ -6,9 +6,12 @@ aliases:
 The *Computational Diffie-Hellman (CDH)* is a central assumption in cryptography. It is a natural strengthening of the [[Decisional Diffie-Hellman|DDH]] assumption. In other words, an adversary which can solve the CDH problem can also solve [[Decisional Diffie-Hellman|DDH]] in the same group.
 
 ## Assumption
-For a family of cyclic groups $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ Define the *CDH-advantage* of an adversary $\mathcal{A}$ as $$\text{Adv}^{\text{cdh}}_{\mathcal{A}}(\lambda) = \Pr[\mathcal{A}(1^{\lambda},g,g^x, g^y)=g^{xy}],$$ where $g$ is the generator for $\mathbb{G}_{\lambda}$ and each $x,y$ is selected uniformly at random between $0$ and $|\mathbb{G}_{\lambda}| - 1$, inclusive.
+Informally, the CDH assumption concerns a cyclic group $\mathbb{G}$ and a generator $g$. The assumption is that given any group elements $g^x$ and $g^y$ (where $x$ and $y$ were chosen uniformly and independently from $\{0, \cdots, |\mathbb{G} - 1|\}$), it is hard to compute the group element $g^{xy}$.
 
-Then, we say that *CDH is hard* for some group family $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ if there exists a negligible function $\nu$ such that for all efficient adversaries $\mathcal{A}$, $$\text{Adv}^{\text{cdh}}_{\mathcal{A}}(\lambda) \le \nu(\lambda).$$
+Formally, consider a family of cyclic groups $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$. Define the *CDH-advantage* of an adversary $\mathcal{A}$ as $$\text{Adv}^{\text{cdh}}_{\mathcal{A}}(\lambda) = \Pr[\mathcal{A}(1^{\lambda},g,g^x, g^y)=g^{xy}],$$ where $g$ is the generator for $\mathbb{G}_{\lambda}$ and $x$ and $y$ are selected uniformly at random from the set $\{0, 1, \cdots, |\mathbb{G}_{\lambda}| - 1\}$.
+
+We say that *CDH is hard* for some group family $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ if there exists a negligible function $\nu$ such that for all efficient adversaries $\mathcal{A}$, $$\text{Adv}^{\text{cdh}}_{\mathcal{A}}(\lambda) \le \nu(\lambda).$$
+
 ### Variations
 In the above definition, we implicitly assume that $\mathbb{G}_{\lambda}$ has a fixed generator. However, [[BMZ19 - The Distinction Between Fixed and Random Generators in Group-Based Assumptions|BMZ19]] has explored technical differences between this model and one where $g$ is selected among many random generators.
 

--- a/Assumptions/Decisional Diffie-Hellman.md
+++ b/Assumptions/Decisional Diffie-Hellman.md
@@ -10,7 +10,7 @@ Informally, the DDH assumption concerns a cyclic group $\mathbb{G}$ and a genera
 
 Formally, consider a family of cyclic groups $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$. Define the *DDH-advantage* of an adversary $\mathcal{A}$ as $$\text{Adv}^{\text{ddh}}_{\mathcal{A}}(\lambda) = \big|\Pr[\mathcal{A}(1^{\lambda},g,g^x, g^y, g^{xy})=1] - \Pr[\mathcal{A}(1^{\lambda},g,g^{x},g^{y},g^{z})=1]\big|,$$ where $g$ is the generator for $\mathbb{G}_{\lambda}$ and $x$, $y$, and $z$ are selected uniformly at random from the set $\{0, 1, \cdots, |\mathbb{G}_{\lambda}| - 1\}$.
 
-Then, we say that *DDH is hard* for some group family $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ if there exists a negligible function $\nu$ such that for all efficient adversaries, $$\text{Adv}^{\text{ddh}}_{\mathcal{A}}(\lambda) \le \nu(\lambda).$$
+We say that *DDH is hard* for some group family $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ if there exists a negligible function $\nu$ such that for all efficient adversaries, $$\text{Adv}^{\text{ddh}}_{\mathcal{A}}(\lambda) \le \nu(\lambda).$$
 
 ### Variations
 In the above definition, we implicitly assume that $\mathbb{G}_{\lambda}$ has a fixed generator. However, [[BMZ19 - The Distinction Between Fixed and Random Generators in Group-Based Assumptions|BMZ19]] has explored technical differences between this model and one where $g$ is selected among many random generators.

--- a/Assumptions/Decisional Diffie-Hellman.md
+++ b/Assumptions/Decisional Diffie-Hellman.md
@@ -6,9 +6,12 @@ aliases:
 The *Decisional Diffie-Hellman (DDH)* is a central assumption in cryptography, and one of the first used to construct key exchange [[DH76 - New Directions in Cryptography|DH76]].
 
 ## Assumption
-For a family of cyclic groups $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ Define the *DDH-advantage* of an adversary $\mathcal{A}$ as $$\text{Adv}^{\text{ddh}}_{\mathcal{A}}(\lambda) = \big|\Pr[\mathcal{A}(1^{\lambda},g,g^x, g^y, g^{xy})=1] - \Pr[\mathcal{A}(1^{\lambda},g,g^{x},g^{y},g^{z})=1]\big|,$$ where $g$ is the generator for $\mathbb{G}_{\lambda}$ and each $x,y,z$ is selected uniformly at random between $0$ and $|\mathbb{G}_{\lambda}| - 1$, inclusive.
+Informally, the DDH assumption concerns a cyclic group $\mathbb{G}$ and a generator $g$. The assumption is that given any group elements $g^x$ and $g^y$ (where $x$ and $y$ were chosen uniformly and independently from $\{0, \cdots, |\mathbb{G} - 1|\}$) the group element $g^{xy}$ ``looks like" a random element in $\mathbb{G}$. 
+
+Formally, consider a family of cyclic groups $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$. Define the *DDH-advantage* of an adversary $\mathcal{A}$ as $$\text{Adv}^{\text{ddh}}_{\mathcal{A}}(\lambda) = \big|\Pr[\mathcal{A}(1^{\lambda},g,g^x, g^y, g^{xy})=1] - \Pr[\mathcal{A}(1^{\lambda},g,g^{x},g^{y},g^{z})=1]\big|,$$ where $g$ is the generator for $\mathbb{G}_{\lambda}$ and $x$, $y$, and $z$ are selected uniformly at random from the set $\{0, 1, \cdots, |\mathbb{G}_{\lambda}| - 1\}$.
 
 Then, we say that *DDH is hard* for some group family $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ if there exists a negligible function $\nu$ such that for all efficient adversaries, $$\text{Adv}^{\text{ddh}}_{\mathcal{A}}(\lambda) \le \nu(\lambda).$$
+
 ### Variations
 In the above definition, we implicitly assume that $\mathbb{G}_{\lambda}$ has a fixed generator. However, [[BMZ19 - The Distinction Between Fixed and Random Generators in Group-Based Assumptions|BMZ19]] has explored technical differences between this model and one where $g$ is selected among many random generators.
 

--- a/Assumptions/Discrete logarithm.md
+++ b/Assumptions/Discrete logarithm.md
@@ -6,15 +6,17 @@ aliases:
 The *discrete logarithm (DLOG)* assumption is used throughout cryptography. It is a natural strengthening of the [[Computational Diffie-Hellman|CDH]] assumption. In other words, an adversary which can solve the DLOG problem can also solve [[Computational Diffie-Hellman|CDH]] in the same group.
 
 ## Assumption
-For a family of cyclic groups $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$, define the *DLOG-advantage* of an adversary $\mathcal{A}$ as $$\text{Adv}^{\text{dlog}}_{\mathcal{A}}(\lambda) = \Pr[\mathcal{A}(1^{\lambda},g,g^x)=x],$$ where $g$ is the generator for $\mathbb{G}_{\lambda}$ and $x$ is selected uniformly at random between $0$ and $|\mathbb{G}_{\lambda}| - 1$, inclusive.
+Informally, the CDH assumption concerns a cyclic group $\mathbb{G}$ and a generator $g$. The assumption is that given any group element $g^x$ (where $x$ was chosen uniformly from $\{0, \cdots, |\mathbb{G} - 1|\}$), it is hard to compute $x$.
 
-Then, we say that *DLOG is hard* for some group family $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ if there exists a negligible function $\nu$ such that for all efficient adversaries $\mathcal{A}$, $$\text{Adv}^{\text{dlog}}_{\mathcal{A}}(\lambda) \le \nu(\lambda).$$
+Formally, consider a family of cyclic groups $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$. Define the *DLOG-advantage* of an adversary $\mathcal{A}$ as $$\text{Adv}^{\text{dlog}}_{\mathcal{A}}(\lambda) = \Pr[\mathcal{A}(1^{\lambda},g,g^x)=x],$$ where $g$ is the generator for $\mathbb{G}_{\lambda}$ and $x$ is selected uniformly at random from the set $\{0, 1, \cdots, |\mathbb{G}_{\lambda}| - 1\}$.
+
+We say that *DLOG is hard* for some group family $\{\mathbb{G}_{\lambda}\}_{\lambda \in \mathbb{N}}$ if there exists a negligible function $\nu$ such that for all efficient adversaries $\mathcal{A}$, $$\text{Adv}^{\text{dlog}}_{\mathcal{A}}(\lambda) \le \nu(\lambda).$$
 ### Variations
 In the above definition, we implicitly assume that $\mathbb{G}_{\lambda}$ has a fixed generator. However, [[BMZ19 - The Distinction Between Fixed and Random Generators in Group-Based Assumptions|BMZ19]] has explored technical differences between this model and one where $g$ is selected among many random generators.
 
 
 ## Related results
-- It is easy to see that if $\mathcal{A}$ can compute $x$ for a random $g^x$, then $\mathcal{A}$ can compute both $x$ and $y$ from $g^{x}$ and $g^{y}$ and therefore, find $g^{xy}$ easily. This establishes that DLOG is a strictly harder problem to solve than [[Computational Diffie-Hellman|CDH]].
+- It is easy to see that if $\mathcal{A}$ can compute $x$ for a random $g^x$, then $\mathcal{A}$ can compute both $x$ and $y$ from $g^{x}$ and $g^{y}$ and find $g^{xy}$ easily. This establishes that DLOG is a strictly harder problem to solve than [[Computational Diffie-Hellman|CDH]].
 - In the [[Generic Group Model]], $\text{Adv}^{\text{dlog}}_{\mathcal{A}}(\lambda) \le \frac{q^2}{|\mathbb{G}_{\lambda}|}$, where $q$ is the number of queries that $\mathcal{A}$ issues — [[Shoup97 - Lower Bounds for Discrete Logarithms and Related Problems|Shoup97]]
 
 


### PR DESCRIPTION
For DDH, CDH, and DLOG, I added a short paragraph explaining the assumption intuitively. (I think it would be helpful to do this with the other assumptions as well.) I also fixed some typos and made some edits for clarity.

One question. See this section from Related Results in CDH: (emphasis mine)

> It is easy to see that if $\mathcal{A}$ can compute $g^{xy}$, then $\mathcal{A}$ can easily distinguish between $g^{xy}$ and a random group element. This establishes that CDH is a **strictly** harder problem to solve than [[Decisional Diffie-Hellman|DDH]].

Why does this establish that CDH is strictly harder? I see how it can't be easier, but that's all I see.... The same phrasing is used in DLOG.