### PR TITLE
Add GGM/AGM glossary pages with Shoup, Maurer, and recent comparisons

### DIFF
--- a/content/Glossary/algebraic-group-model.md
+++ b/content/Glossary/algebraic-group-model.md
@@ -1,0 +1,44 @@
+---
+aliases:
+  - AGM
+  - Algebraic Group Model
+title: Algebraic Group Model
+---
+# Algebraic Group Model
+
+The *Algebraic Group Model (AGM)* [[FKL18 - The Algebraic Group Model and its Applications|FKL18]] is a model of computation that lies between the standard model and the [[generic-group-model|Generic Group Model (GGM)]]. In it, adversaries are restricted to being *algebraic*: they can perform arbitrary group computations, but must be able to account for every group element they produce by explaining it as a linear combination of previously seen elements.
+
+## Definition
+
+Let $(\GG, g, p) \gets \GrGen(1^\secpar)$. An adversary $\calA$ is **algebraic** if, for every group element $Z \in \GG$ that $\calA$ outputs, it simultaneously outputs a vector of exponents $(\alpha_1, \ldots, \alpha_k) \in \ZZ_p^k$ such that
+
+$$
+Z = \prod_{i=1}^{k} A_i^{\alpha_i},
+$$
+
+where $(A_1, \ldots, A_k)$ is the ordered list of all group elements $\calA$ has received as inputs or as outputs of prior computations up to that point. This vector is called a **representation** of $Z$.
+
+Informally, an algebraic adversary must "explain" every group element it uses. It cannot treat group elements as black-box tokens: any element it outputs must be derivable via known exponent arithmetic from elements it has already seen.
+
+## Key Results
+
+The following results are due to [[FKL18 - The Algebraic Group Model and its Applications|FKL18]] for algebraic adversaries in cyclic groups:
+
+- **CDH $\equiv_{\mathrm{AGM}}$ DLOG:** any algebraic CDH adversary can be converted into a DLOG adversary with the same advantage and essentially the same running time.
+- **DDH $\leq_{\mathrm{AGM}}$ DLOG:** DDH reduces tightly to DLOG in the AGM.
+- **BLS security:** unforgeability of [[boneh-lynn-shacham-signature|BLS]] signatures reduces tightly to DLOG in the AGM.
+- **Groth's SNARK:** the knowledge-soundness of Groth's zero-knowledge SNARK holds in the AGM.
+
+These reductions, combined with the $\Omega(\sqrt{p})$ GGM lower bound of [[Sho97 - Lower Bounds for Discrete Logarithms and Related Problems|Sho97]], yield tight concrete lower bounds for CDH and related problems against algebraic-and-generic adversaries.
+
+## Comparison with the GGM
+
+The relationship between the AGM and the [[generic-group-model|GGM]] has been the subject of significant study.
+
+[[FKL18 - The Algebraic Group Model and its Applications|FKL18]] claimed that the AGM is *strictly weaker* than the GGM in the sense that hardness for algebraic adversaries implies hardness for generic adversaries. Under this view, every GGM-secure scheme is AGM-secure, and AGM lower bounds lift to the GGM.
+
+[[KZ22 - An Analysis of the Algebraic Group Model|Katz and Zhang (KZ22)]] challenged this claim: they showed that hardness in the AGM does not in general imply hardness in the GGM, and that generic reductions in the AGM need not yield analogous reductions in the GGM. The precise conditions under which AGM proofs transfer to the GGM remain an active area of research.
+
+## Comparison with the Standard Model
+
+In the standard model, an adversary receives group elements and may compute arbitrary group operations, with no restriction on how it uses or derives elements. The AGM adds a single constraint — the algebraic accountability condition — that enables tight reductions which are not known in the standard model. In this sense, the AGM is a *conservative idealization*: it rules out adversaries that could exploit the representation of group elements in a way that a real-world adversary plausibly cannot.

--- a/content/Glossary/generic-group-model.md
+++ b/content/Glossary/generic-group-model.md
@@ -5,6 +5,40 @@ aliases:
 title: Generic Group Model
 ---
 # Generic Group Model
-The *Generic Group Model (GGM)* was a model introduced by [[Sho97 - Lower Bounds for Discrete Logarithms and Related Problems|Shoup97]] as a method for analyzing the security of (cyclic) group-based assumptions.
 
-In (Shoup's) GGM, every group element is given a random unique bit-string called a handle. Then, and adversary can compute the group operation by calling its oracle, which takes two handles an outputs a handle that represents the product of the input elements.
+The *Generic Group Model (GGM)* is a model for analyzing the security of group-based cryptographic assumptions. It restricts adversaries to those that cannot exploit any special properties of how group elements are represented, interacting with the group only through an oracle. The model was independently proposed by Shoup [[Sho97 - Lower Bounds for Discrete Logarithms and Related Problems|Sho97]] and Maurer [[Mau05 - Abstract Models of Computation in Cryptography|Mau05]]; the two formulations differ in important ways.
+
+## Shoup's Formulation
+
+Let $(\GG, g, p) \gets \GrGen(1^\secpar)$ be a cyclic group of prime order $p$. A **handle function** is a random injection $\sigma: \GG \to \{0,1\}^n$, which assigns each group element a unique opaque bit-string called a *handle*. The adversary is only ever given handles — never actual group elements — and must compute via oracle queries:
+
+- **Group operation:** $\calO_{\mathsf{op}}(\sigma(X), \sigma(Y)) \to \sigma(X \cdot Y)$
+- **Inversion:** $\calO_{\mathsf{inv}}(\sigma(X)) \to \sigma(X^{-1})$
+
+Equality of group elements is implicit: since $\sigma$ is injective, two handles are equal iff the underlying elements are. An algorithm is **generic** (in Shoup's sense) if it succeeds at a computational task for every choice of injection $\sigma$.
+
+The key result of [[Sho97 - Lower Bounds for Discrete Logarithms and Related Problems|Shoup97]] is that any generic algorithm solving [[discrete-logarithm|DLOG]], [[computational-diffie-hellman|CDH]], or [[decisional-diffie-hellman|DDH]] in a group of prime order $p$ must issue $\Omega(\sqrt{p})$ oracle queries. Combined with the Baby-step Giant-step algorithm, this is tight.
+
+## Maurer's Formulation
+
+In [[Mau05 - Abstract Models of Computation in Cryptography|Maurer's]] formulation, genericity is captured algebraically rather than via random encodings. A group of order $p$ is presented to the adversary via a surjective group homomorphism $\phi: \ZZ_p^n \to \GG$, where $\ZZ_p^n$ is the "label space." The adversary sees only labels (elements of $\ZZ_p^n$), and queries a group operation oracle that computes $\phi(\mathbf{u}) \cdot \phi(\mathbf{v}) = \phi(\mathbf{u} + \mathbf{v})$. An algorithm is **generic** if it succeeds for every such homomorphism $\phi$.
+
+This captures a different notion of independence from the group representation, and connects more naturally to the algebraic structure of $\ZZ_p$.
+
+## Comparing the Two Formulations
+
+Jager and Schwenk [[JS08 - On the Equivalence of Generic Group Models|JS08]] argued that Shoup's and Maurer's formulations are equivalent for standard cyclic groups. However, Maurer, Portmann, and Zhu [[MPZ20 - Unifying Generic Group Models|MPZ20]] showed this is not generally true. They identify a key source of divergence: in Shoup's model, the adversary can test equality of handles (implicitly, across *all* known elements at once), whereas Maurer's label-based approach encodes equality differently. MPZ20 establish a precise hierarchy of GGM variants — parameterized by the set of available queries — and show that the two original models occupy different positions in this hierarchy.
+
+## The Structured GGM
+
+Corrigan-Gibbs, Henzinger, and Wu [[CHW26 - The Structured Generic-Group Model|CHW26]] extend Shoup's model to capture algorithms that exploit non-generic structure in a controlled way. In the **structured GGM**, the adversary may exploit special structure for at most a $\delta$ fraction of group elements while remaining fully generic on the rest. The main result is that any DLOG algorithm in a group of prime order $p$ that exploits structure on at most a $\delta$ fraction of elements requires time
+
+$$
+\Omega\!\left(\min\!\left(\sqrt{p},\; \frac{1}{\delta}\right)\right).
+$$
+
+This yields tight subexponential lower bounds applicable to index-calculus algorithms, bridging the gap between fully generic lower bounds and structured algorithm analyses.
+
+## Comparison with the AGM
+
+The [[algebraic-group-model|Algebraic Group Model (AGM)]] is a strictly *weaker* idealization: every generic algorithm (in Shoup's or Maurer's sense) satisfies the AGM's algebraic accountability condition, but not conversely. Security proven only in the AGM does not automatically imply security in the GGM.

--- a/content/References/CHW26 - The Structured Generic-Group Model.md
+++ b/content/References/CHW26 - The Structured Generic-Group Model.md
@@ -1,0 +1,17 @@
+---
+title: "CHW26"
+source: https://eprint.iacr.org/2026/384
+authors: Corrigan-Gibbs, Henry; Henzinger, Alexandra; Wu, David J.
+venue: Eurocrypt 2026
+published: 2026-01-01
+aliases:
+  - CHW26
+tags:
+  - Eurocrypt
+---
+# [CHW26] The Structured Generic-Group Model
+
+**Authors:** Corrigan-Gibbs, Henry; Henzinger, Alexandra; Wu, David J. | **Venue:** Eurocrypt 2026 | [Source](https://eprint.iacr.org/2026/384)
+
+## Abstract
+This paper extends Shoup's generic group model to analyze algorithms that exploit non-generic structure of the group. In the structured GGM, an adversary is allowed to exploit the special structure of at most a $\delta$ fraction of group elements, while remaining generic on the rest. The main result is that any discrete-logarithm algorithm in a group of prime order $p$ that exploits structure in at most a $\delta$ fraction of elements must run in time $\Omega(\min(\sqrt{p},\, 1/\delta))$. This yields tight subexponential lower bounds against index-calculus-style algorithms that exploit smooth-integer multiplicative structure, bridging the gap between fully generic lower bounds and structured algorithm analyses.

--- a/content/References/FKL18 - The Algebraic Group Model and its Applications.md
+++ b/content/References/FKL18 - The Algebraic Group Model and its Applications.md
@@ -1,0 +1,17 @@
+---
+title: "FKL18"
+source: https://eprint.iacr.org/2017/620
+authors: Fuchsbauer, Georg; Kiltz, Eike; Loss, Julian
+venue: CRYPTO 2018
+published: 2018-01-01
+aliases:
+  - FKL18
+tags:
+  - CRYPTO
+---
+# [FKL18] The Algebraic Group Model and its Applications
+
+**Authors:** Fuchsbauer, Georg; Kiltz, Eike; Loss, Julian | **Venue:** CRYPTO 2018 | [Source](https://eprint.iacr.org/2017/620)
+
+## Abstract
+This paper introduces the *Algebraic Group Model (AGM)*, a model of computation that lies strictly between the standard model and the generic group model. An adversary in the AGM is *algebraic*: whenever it outputs a group element, it must simultaneously provide an explicit linear representation of that element over the group elements it has received. The authors show that several important assumptions — CDH, Strong DH, and the interactive LRSW assumption — are equivalent to the discrete logarithm assumption in the AGM, and prove tight security reductions for BLS signatures and Groth's zero-knowledge SNARK. Combined with GGM lower bounds, these yield tight lower bounds for various group-based constructions.

--- a/content/References/JS08 - On the Equivalence of Generic Group Models.md
+++ b/content/References/JS08 - On the Equivalence of Generic Group Models.md
@@ -1,0 +1,17 @@
+---
+title: "JS08"
+source: https://link.springer.com/chapter/10.1007/978-3-540-88733-1_14
+authors: Jager, Tibor; Schwenk, Jörg
+venue: ProvSec 2008
+published: 2008-01-01
+aliases:
+  - JS08
+tags:
+  - ProvSec
+---
+# [JS08] On the Equivalence of Generic Group Models
+
+**Authors:** Jager, Tibor; Schwenk, Jörg | **Venue:** ProvSec 2008 (LNCS 5324) | [Source](https://link.springer.com/chapter/10.1007/978-3-540-88733-1_14)
+
+## Abstract
+This paper considers the relationship between Shoup's and Maurer's formulations of the generic group model. The authors argue that for standard cyclic groups, the two models are equivalent in the sense that any security statement provable in one can be translated to the other. However, this equivalence claim was later challenged by [[MPZ20 - Unifying Generic Group Models|Maurer, Portmann, and Zhu]], who showed that the two models differ in general and are not always equivalent.

--- a/content/References/KZ22 - An Analysis of the Algebraic Group Model.md
+++ b/content/References/KZ22 - An Analysis of the Algebraic Group Model.md
@@ -1,0 +1,17 @@
+---
+title: "KZ22"
+source: https://eprint.iacr.org/2022/210
+authors: Katz, Jonathan; Zhang, Cong
+venue: ASIACRYPT 2022
+published: 2022-01-01
+aliases:
+  - KZ22
+tags:
+  - ASIACRYPT
+---
+# [KZ22] An Analysis of the Algebraic Group Model
+
+**Authors:** Katz, Jonathan; Zhang, Cong | **Venue:** ASIACRYPT 2022 | [Source](https://eprint.iacr.org/2022/210)
+
+## Abstract
+The algebraic group model (AGM), formalized by Fuchsbauer, Kiltz, and Loss, was claimed to be a weaker model than the generic group model (GGM) in the sense that hardness for algebraic algorithms implies hardness for generic algorithms, and generic reductions in the AGM lift to the GGM. This paper challenges those claims: the authors identify settings where hardness in the AGM does not imply hardness in the GGM, and where a generic reduction in the AGM does not yield a corresponding reduction in the GGM. The results clarify the relationship between the two models and show that the hierarchy assumed in prior work is not generally valid.

--- a/content/References/MPZ20 - Unifying Generic Group Models.md
+++ b/content/References/MPZ20 - Unifying Generic Group Models.md
@@ -1,0 +1,15 @@
+---
+title: "MPZ20"
+source: https://eprint.iacr.org/2020/996
+authors: Maurer, Ueli; Portmann, Christopher; Zhu, Jiamin
+venue: ePrint 2020/996
+published: 2020-01-01
+aliases:
+  - MPZ20
+---
+# [MPZ20] Unifying Generic Group Models
+
+**Authors:** Maurer, Ueli; Portmann, Christopher; Zhu, Jiamin | **Venue:** ePrint 2020/996 | [Source](https://eprint.iacr.org/2020/996)
+
+## Abstract
+Several different generic group models have appeared in the literature, making it difficult to compare results and match lower and upper bounds. This paper develops a unifying framework: a model is viewed as a set of games with the same type of adversary interactions, and models are compared via standard game reductions. Using this framework, the authors establish a hierarchy of GGM variants parameterized by the set of queries available to the adversary, and disprove the claimed equivalence between Shoup's and Maurer's formulations by exhibiting a separation. They show that the two models differ in how equality-testing interacts with the group presentation, and clarify exactly which reductions between them hold.

--- a/content/References/Mau05 - Abstract Models of Computation in Cryptography.md
+++ b/content/References/Mau05 - Abstract Models of Computation in Cryptography.md
@@ -1,0 +1,17 @@
+---
+title: "Mau05"
+source: https://link.springer.com/chapter/10.1007/11586821_1
+authors: Maurer, Ueli
+venue: IMA Cryptography and Coding 2005
+published: 2005-01-01
+aliases:
+  - Mau05
+tags:
+  - IMA
+---
+# [Mau05] Abstract Models of Computation in Cryptography
+
+**Authors:** Maurer, Ueli | **Venue:** IMA Cryptography and Coding 2005 (LNCS 3796) | [Source](https://link.springer.com/chapter/10.1007/11586821_1)
+
+## Abstract
+This paper proposes a general framework for abstract models of computation in cryptography, of which the random oracle model and the generic group model are special cases. In Maurer's formulation, a computation model is defined by an interface that specifies a set of oracles available to an algorithm, modeling access to an idealized cryptographic object. This approach yields a clean algebraic characterization of "generic" algorithms — those that interact with a group only through a homomorphism — and provides a foundation for comparing different idealized models via reductions between interfaces.


### PR DESCRIPTION
## Summary

- **Expands** `content/Glossary/generic-group-model.md` from a 2-sentence stub into a full glossary entry covering Shoup's handle-based formulation, Maurer's homomorphism-based formulation, the MPZ20 non-equivalence result, and the CHW26 structured GGM extension
- **Adds** `content/Glossary/algebraic-group-model.md` — formal definition of algebraic adversaries, key FKL18 results (CDH ≡ DLOG, BLS, Groth SNARK), and the KZ22 challenge to the AGM⟹GGM claim
- **Adds 6 reference files:** Mau05, JS08, MPZ20, CHW26, FKL18, KZ22

## Test plan

- [ ] `npm run check` — TypeScript + Prettier validation
- [ ] `npx quartz build --serve` and verify `/Glossary/generic-group-model` and `/Glossary/algebraic-group-model` render correctly (math, wiki links, section structure)
- [ ] Confirm existing wiki links to `[[generic-group-model|GGM]]` on DL/CDH/DDH assumption pages still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)