### PR TITLE
Add Fiat-Shamir heuristic glossary entry and related references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ workspace.json
 node_modules/
 public/
 quartz/.quartz-cache/
+tsconfig.tsbuildinfo

--- a/content/Glossary/fiat-shamir-heuristic.md
+++ b/content/Glossary/fiat-shamir-heuristic.md
@@ -5,3 +5,28 @@ aliases:
 title: Fiat-Shamir Heuristic
 ---
 # Fiat-Shamir Heuristic
+The *Fiat-Shamir heuristic* (or *Fiat-Shamir transform*) is a technique for compiling a public-coin interactive protocol into a non-interactive one by replacing the verifier's random challenges with the output of a hash function applied to the transcript so far. The transform is proven secure when the hash function is modeled as a [[random-oracle-model|random oracle]], but is known to fail in important settings when instantiated with concrete hash functions.
+
+## Description
+
+Given a $(2k+1)$-message public-coin interactive protocol $\Pi = (P, V)$ with messages $a_1, c_1, \ldots, a_k, c_k, a_{k+1}$, the Fiat-Shamir transform produces a non-interactive protocol $\Pi_\mathsf{FS}$ as follows: the prover computes each verifier challenge itself as
+
+$$c_i := H(a_1, c_1, \ldots, a_{i-1}, c_{i-1}, a_i),$$
+
+where $H$ is a hash function modeled as a random oracle. The resulting proof $(a_1, c_1, \ldots, a_{k+1})$ can be verified by any party who recomputes the same hash challenges.
+
+The transform is particularly useful for constructing [[digital-signature|digital signatures]] from identification schemes (the original application of Fiat and Shamir), and for building non-interactive zero-knowledge proofs and succinct arguments.
+
+## Security in the ROM
+
+In the [[random-oracle-model|random oracle model]], the Fiat-Shamir transform preserves soundness and zero-knowledge (and simulation-extractability) for a broad class of protocols. This is the primary justification for its widespread use.
+
+## Known Failures
+
+### Standard Model (GK03)
+Goldwasser and Kalai showed that the Fiat-Shamir transform is uninstantiable in the standard model [[GK03 - On the (In)security of the Fiat-Shamir Paradigm|GK03]]. They constructed a 3-round public-coin identification scheme that is secure in the ROM, yet whose Fiat-Shamir transform is existentially forgeable under *every* concrete hash function. This demonstrates that the random oracle cannot always be replaced by an actual hash function, even a cryptographically strong one.
+
+$$\Adv^{\mathrm{uf}}_{\Pi_H, \calA}(\secpar) \ge 1 - \negl(\secpar) \quad \text{for all } H.$$
+
+### Natural Protocols (KRS25)
+Prior counterexamples to Fiat-Shamir were contrived — protocols specifically engineered to fail. Khovratovich, Rothblum, and Soukhanov gave the first counterexample for a *standard, widely-studied* protocol [[KRS25 - How to Prove False Statements Practical Attacks on Fiat-Shamir|KRS25]]. They showed that the Fiat-Shamir transform applied to the GKR succinct interactive argument (from [[GKR15 - Delegating Computation Interactive Proofs for Muggles|GKR15]]) allows an efficient prover to prove *false* statements for explicit families of circuits. This raises serious questions about the security of deployed non-interactive succinct arguments based on Fiat-Shamir.

--- a/content/Glossary/random-oracle-model.md
+++ b/content/Glossary/random-oracle-model.md
@@ -8,4 +8,14 @@ title: Random Oracle Model
 # Random Oracle Model
 The *Random Oracle Model (ROM)* is a heuristic commonly used in cryptography to prove security of systems, which are either difficult or impossible to prove secure otherwise. In this model, all parties are given access to an oracle, which is instantiated as a random and independent function. Then, proofs argue with high probability over the choice of a random oracle, schemes remain secure.
 
-Early work in cryptography showed some issues with the random oracle model [[CCG+94 - The random oracle hypothesis is false|CCG+94]], for example that [[interactive-proof-systems|IP]] != [[polynomial-space|PSPACE]] relative to a random oracle.
+The ROM is related to the *Random Oracle Hypothesis* (attributed to Bennett and Gill), which conjectured that complexity-class relationships holding for almost all relativized worlds also hold unrelativized. The hypothesis was disproved by [[CCG+94 - The random oracle hypothesis is false|CCG+94]].
+
+# Known Results
+
+- **[[interactive-proof-systems|IP]] $\neq$ [[polynomial-space|PSPACE]] relative to a random oracle** — For almost all oracles $A$, $\mathsf{IP}^A \neq \mathsf{PSPACE}^A$ [[CCG+94 - The random oracle hypothesis is false|CCG+94]]. Since Shamir proved $\mathsf{IP} = \mathsf{PSPACE}$ unrelativized, this is among the most compelling counterexamples to the Random Oracle Hypothesis.
+
+- **[[fiat-shamir-heuristic|Fiat-Shamir]] is uninstantiable in the standard model** — Goldwasser and Kalai constructed a 3-round public-coin protocol whose Fiat-Shamir transform is existentially forgeable under every concrete hash function, even though it is secure in the ROM [[GK03 - On the (In)security of the Fiat-Shamir Paradigm|GK03]]. This shows the random oracle cannot always be replaced by a concrete function.
+
+- **Fiat-Shamir fails for the GKR protocol** — Khovratovich, Rothblum, and Soukhanov showed that the [[fiat-shamir-heuristic|Fiat-Shamir]] transform fails for the GKR succinct interactive argument — a standard, widely-studied protocol, not a contrived one [[KRS25 - How to Prove False Statements Practical Attacks on Fiat-Shamir|KRS25]]. They exhibit families of circuits for which the non-interactive GKR argument proves false statements.
+
+- **OIHFs bridge Minicrypt and Cryptomania non-black-box** — Barnum and Heath introduced *Oblivious Interactive Hash Functions* (OIHFs), a primitive that can be constructed from a random oracle, yet implies [[oblivious-transfer|OT]] via a non-black-box reduction [[BH26 - How to Steal Oblivious Transfer from Minicrypt|BH26]]. This partially bridges the classical separation between Minicrypt (one-way functions, PRFs, etc.) and Cryptomania (public-key primitives including OT), though the non-black-box OT construction from a standard-model OIHF currently requires Cryptomania assumptions.

--- a/content/References/BH26 - How to Steal Oblivious Transfer from Minicrypt.md
+++ b/content/References/BH26 - How to Steal Oblivious Transfer from Minicrypt.md
@@ -1,0 +1,18 @@
+---
+title: "BH26"
+source: https://eprint.iacr.org/2026/113
+authors: Cruz Barnum, David Heath
+venue: ePrint 2026
+published: 2026-02-13
+aliases:
+  - BH26
+tags:
+  - ePrint
+
+---
+# [BH26] How to Steal Oblivious Transfer from Minicrypt
+
+**Authors:** Cruz Barnum, David Heath | **Venue:** ePrint 2026 | [Source](https://eprint.iacr.org/2026/113)
+
+## Abstract
+We introduce *Oblivious Interactive Hash Functions* (OIHFs), a new cryptographic primitive that sits between Minicrypt and Cryptomania. We show: (1) OIHFs can be constructed from a random oracle (placing them in Minicrypt); (2) OIHFs imply oblivious transfer via a non-black-box reduction; and (3) OIHFs can be constructed from oblivious transfer. The non-black-box implication of OT from OIHFs challenges the classical 36-year-old separation between Minicrypt and Cryptomania established by Impagliazzo and Rudich. However, constructing OIHFs in the standard model (without a random oracle) currently requires Cryptomania assumptions, so the full separation remains intact for black-box constructions.

--- a/content/References/GK03 - On the (In)security of the Fiat-Shamir Paradigm.md
+++ b/content/References/GK03 - On the (In)security of the Fiat-Shamir Paradigm.md
@@ -1,0 +1,18 @@
+---
+title: "GK03"
+source: https://eprint.iacr.org/2003/034
+authors: Shafi Goldwasser, Yael Tauman Kalai
+venue: FOCS 2003
+published: 2003-01-01
+aliases:
+  - GK03
+tags:
+  - FOCS
+
+---
+# [GK03] On the (In)security of the Fiat-Shamir Paradigm
+
+**Authors:** Shafi Goldwasser, Yael Tauman Kalai | **Venue:** FOCS 2003 | [Source](https://eprint.iacr.org/2003/034)
+
+## Abstract
+We show that the Fiat-Shamir transform is not sound in the standard model in general. Specifically, we construct a 3-round public-coin identification scheme that is secure in the random oracle model, yet for which the Fiat-Shamir signature scheme (obtained by replacing the random oracle with any concrete hash function) is existentially forgeable. More precisely, we show that for any concrete hash function $H$, the resulting signature scheme can be broken by an efficient adversary. Our techniques use non-black-box methods and demonstrate that the random oracle cannot be instantiated in general.

--- a/content/References/KRS25 - How to Prove False Statements Practical Attacks on Fiat-Shamir.md
+++ b/content/References/KRS25 - How to Prove False Statements Practical Attacks on Fiat-Shamir.md
@@ -1,0 +1,18 @@
+---
+title: "KRS25"
+source: https://eprint.iacr.org/2025/118
+authors: Dmitry Khovratovich, Ron Rothblum, Oleg Soukhanov
+venue: CRYPTO 2025
+published: 2025-01-01
+aliases:
+  - KRS25
+tags:
+  - CRYPTO
+
+---
+# [KRS25] How to Prove False Statements: Practical Attacks on Fiat-Shamir
+
+**Authors:** Dmitry Khovratovich, Ron Rothblum, Oleg Soukhanov | **Venue:** CRYPTO 2025 | [Source](https://eprint.iacr.org/2025/118)
+
+## Abstract
+The Fiat-Shamir (FS) transform is a prolific technique for compiling public-coin interactive protocols into non-interactive ones by replacing verifier randomness with hash function evaluations. The FS transform is provably sound in the random oracle model. However, when instantiating the random oracle with a concrete hash function, there exist protocols for which soundness fails. Until this work, all known counterexamples were contrived — specifically engineered to make Fiat-Shamir fail. We show that Fiat-Shamir fails for the GKR succinct interactive argument (a standard, widely-studied protocol): we exhibit explicit families of circuits for which an efficient prover can produce an accepting non-interactive GKR proof of a *false* statement. This is the first counterexample to Fiat-Shamir applied to a natural protocol, raising fundamental questions about the security of deployed non-interactive succinct arguments.


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the Fiat-Shamir heuristic, a fundamental technique in cryptography for converting interactive protocols to non-interactive ones. It includes the main glossary entry, three key reference papers, and updates the Random Oracle Model entry with related results.

## Key Changes

- **New Fiat-Shamir Heuristic glossary entry** — Comprehensive explanation of the technique, including:
  - Definition and description of the transform
  - Security properties in the random oracle model
  - Two major categories of known failures:
    - GK03: Theoretical uninstantiability in the standard model
    - KRS25: Practical attacks on the widely-used GKR protocol

- **Added three reference papers:**
  - `GK03` — Goldwasser & Kalai's foundational result showing Fiat-Shamir is uninstantiable in the standard model
  - `KRS25` — Khovratovich, Rothblum & Soukhanov's practical counterexample for the GKR protocol
  - `BH26` — Barnum & Heath's work on Oblivious Interactive Hash Functions bridging Minicrypt and Cryptomania

- **Updated Random Oracle Model entry** — Added "Known Results" section documenting:
  - The Random Oracle Hypothesis and its disproof
  - Fiat-Shamir uninstantiability results (GK03 and KRS25)
  - OIHF construction results (BH26)
  - Cross-references to related glossary entries

- **Minor housekeeping** — Added `tsconfig.tsbuildinfo` to `.gitignore`

## Notable Details

The Fiat-Shamir entry clearly distinguishes between theoretical failures (contrived protocols in GK03) and practical failures (natural protocols like GKR in KRS25), highlighting why the latter is particularly concerning for deployed systems. All entries include proper citations and cross-references to related cryptographic concepts.

https://claude.ai/code/session_01DJubtRSL8VVd7nfPk38hZa