### PR TITLE
Fix reference formatting: standardize frontmatter, update preprint links

### DIFF
--- a/content/References/AIK06 - Cryptography in NC0.md
+++ b/content/References/AIK06 - Cryptography in NC0.md
@@ -8,6 +8,16 @@ aliases:
   - AIK06
 tags:
   - Journal-on-Computing
+bibtex: |
+  @article{AIK06,
+    author  = {Benny Applebaum and Yuval Ishai and Eyal Kushilevitz},
+    title   = {Cryptography in {NC0}},
+    journal = {SIAM Journal on Computing},
+    volume  = {36},
+    number  = {4},
+    pages   = {845--888},
+    year    = {2006}
+  }
 ---
 
 # [AIK06] Cryptography in $NC^0$

--- a/content/References/AK07 - Quantum versus Classical Proofs and Advice.md
+++ b/content/References/AK07 - Quantum versus Classical Proofs and Advice.md
@@ -8,6 +8,17 @@ aliases:
   - AK07
 tags:
   - CCC
+bibtex: |
+  @article{AK07,
+    author  = {Scott Aaronson and Greg Kuperberg},
+    title   = {Quantum versus Classical Proofs and Advice},
+    journal = {Theory of Computing},
+    volume  = {3},
+    pages   = {129--157},
+    year    = {2007},
+    note    = {Preliminary version in CCC 2007},
+    url     = {https://arxiv.org/abs/quant-ph/0604056}
+  }
 ---
 
 # [AK07] Quantum versus Classical Proofs and Advice

--- a/content/References/AKS83 - An 0(n log n) sorting network.md
+++ b/content/References/AKS83 - An 0(n log n) sorting network.md
@@ -9,6 +9,14 @@ aliases:
   - AKS83
 tags:
   - STOC
+bibtex: |
+  @inproceedings{AKS83,
+    author    = {Mikl\'{o}s Ajtai and J\'{a}nos Koml\'{o}s and Endre Szemer\'{e}di},
+    title     = {An {$O(n \log n)$} Sorting Network},
+    booktitle = {Proceedings of the 15th Annual ACM Symposium on Theory of Computing (STOC 1983)},
+    pages     = {1--9},
+    year      = {1983}
+  }
 ---
 
 # [AKS83] An 0(n log n) sorting network

--- a/content/References/BBHR18 - Scalable, transparent, and post-quantum secure computational integrity.md
+++ b/content/References/BBHR18 - Scalable, transparent, and post-quantum secure computational integrity.md
@@ -1,10 +1,16 @@
 ---
+source: https://eprint.iacr.org/2018/046
 aliases:
   - BBHR18
-title: "BBHR18 - Scalable, transparent, and post-quantum secure computational integrity"
+title: "BBHR18"
 cryptobib_key: EPRINT:BBHR18
+authors: Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, Michael Riabzev
+venue: ePrint 2018
+published: 2018-01-01
 ---
 
-Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, and Michael Riabzev. "Scalable, transparent, and post-quantum secure computational integrity." Cryptology ePrint Archive, Report 2018/046, 2018.
+# [BBHR18] Scalable, transparent, and post-quantum secure computational integrity
+
+**Authors:** Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, Michael Riabzev | **Venue:** ePrint 2018 | [Source](https://eprint.iacr.org/2018/046)
 
 Introduced the STARK (Scalable Transparent ARgument of Knowledge) proof system. STARKs achieve: (1) _transparency_ — no trusted setup; the verifier's randomness is public and the reference string is a random oracle; (2) _post-quantum security_ — security relies only on collision-resistant hash functions; (3) _scalability_ — prover runs in quasi-linear time $O(T \log T)$ for a computation of size $T$; proof size is $O(\log^2 T)$. The core technical tool is FRI (Fast Reed-Solomon IOP of Proximity), a protocol for proximity testing to Reed-Solomon codes that yields an efficient polynomial commitment without a trusted setup.

--- a/content/References/BFL+24 - Quantum Merlin-Arthur with an Internally Separable Proof.md
+++ b/content/References/BFL+24 - Quantum Merlin-Arthur with an Internally Separable Proof.md
@@ -8,6 +8,14 @@ aliases:
   - BFL+24
 tags:
   - arXiv
+bibtex: |
+  @misc{BFL+24,
+    author       = {Roozbeh Bassirian and Bill Fefferman and Itai Leigh and Kunal Marwaha and Pei Wu},
+    title        = {Quantum {Merlin-Arthur} with an Internally Separable Proof},
+    howpublished = {arXiv:2410.19152},
+    year         = {2024},
+    url          = {https://arxiv.org/abs/2410.19152}
+  }
 ---
 
 # [BFL+24] Quantum Merlin-Arthur with an Internally Separable Proof

--- a/content/References/BFM23 - On the Power of Nonstandard Quantum Oracles.md
+++ b/content/References/BFM23 - On the Power of Nonstandard Quantum Oracles.md
@@ -8,6 +8,17 @@ aliases:
   - BFM23
 tags:
   - TQC
+bibtex: |
+  @inproceedings{BFM23,
+    author    = {Roozbeh Bassirian and Bill Fefferman and Kunal Marwaha},
+    title     = {On the Power of Nonstandard Quantum Oracles},
+    booktitle = {18th Conference on the Theory of Quantum Computation, Communication and Cryptography (TQC 2023)},
+    series    = {LIPIcs},
+    volume    = {266},
+    pages     = {11:1--11:25},
+    year      = {2023},
+    url       = {https://arxiv.org/abs/2212.00098}
+  }
 ---
 
 # [BFM23] On the Power of Nonstandard Quantum Oracles

--- a/content/References/BFM88 - Non-interactive zero-knowledge and its applications.md
+++ b/content/References/BFM88 - Non-interactive zero-knowledge and its applications.md
@@ -1,17 +1,16 @@
 ---
-title: Non-Interactive Zero-Knowledge and Its Applications
-URL: https://dl.acm.org/doi/10.1145/62212.62222
+title: "BFM88"
+source: https://dl.acm.org/doi/10.1145/62212.62222
 authors: Manuel Blum, Paul Feldman, Silvio Micali
 venue: STOC 1988
-publish date: 1988
+published: 1988
 aliases:
   - BFM88
 ---
 
-# Non-Interactive Zero-Knowledge and Its Applications
+# [BFM88] Non-Interactive Zero-Knowledge and Its Applications
 
-URL: https://dl.acm.org/doi/10.1145/62212.62222
-Authors: Manuel Blum, Paul Feldman, Silvio Micali
+**Authors:** Manuel Blum, Paul Feldman, Silvio Micali | **Venue:** STOC 1988 | [Source](https://dl.acm.org/doi/10.1145/62212.62222)
 
 ## Abstract
 

--- a/content/References/BFM88 - Non-interactive zero-knowledge and its applications.md
+++ b/content/References/BFM88 - Non-interactive zero-knowledge and its applications.md
@@ -6,6 +6,14 @@ venue: STOC 1988
 published: 1988
 aliases:
   - BFM88
+bibtex: |
+  @inproceedings{BFM88,
+    author    = {Manuel Blum and Paul Feldman and Silvio Micali},
+    title     = {Non-Interactive Zero-Knowledge and Its Applications},
+    booktitle = {Proceedings of the 20th Annual ACM Symposium on Theory of Computing (STOC 1988)},
+    pages     = {103--112},
+    year      = {1988}
+  }
 ---
 
 # [BFM88] Non-Interactive Zero-Knowledge and Its Applications

--- a/content/References/BGI16 - Function Secret Sharing Improvements and Extensions.md
+++ b/content/References/BGI16 - Function Secret Sharing Improvements and Extensions.md
@@ -1,6 +1,6 @@
 ---
 title: "BGI16"
-source: https://dl.acm.org/doi/abs/10.1145/2976749.2978429
+source: https://eprint.iacr.org/2016/585
 authors: Elette Boyle, Niv Gilboa, Yuval Ishai
 venue: CCS 2016
 published: 2016-10-24
@@ -14,7 +14,7 @@ cryptobib_key: CCS:BoyGilIsh16
 
 # [BGI16] Function Secret Sharing: Improvements and Extensions
 
-**Authors:** Elette Boyle, Niv Gilboa, Yuval Ishai | **Venue:** CCS 2016 | [Source](https://dl.acm.org/doi/abs/10.1145/2976749.2978429)
+**Authors:** Elette Boyle, Niv Gilboa, Yuval Ishai | **Venue:** CCS 2016 | [Source](https://eprint.iacr.org/2016/585)
 
 ## Abstract
 

--- a/content/References/BGS75 - Relativizations of the P=NP question.md
+++ b/content/References/BGS75 - Relativizations of the P=NP question.md
@@ -8,6 +8,16 @@ aliases:
   - BGS75
 tags:
   - SICOMP
+bibtex: |
+  @article{BGS75,
+    author  = {Theodore Baker and John Gill and Robert Solovay},
+    title   = {Relativizations of the {$\mathcal{P} =? \mathcal{NP}$} Question},
+    journal = {SIAM Journal on Computing},
+    volume  = {4},
+    number  = {4},
+    pages   = {431--442},
+    year    = {1975}
+  }
 ---
 
 # [BGS75] Relativizations of the P=NP question

--- a/content/References/BGV12 - Leveled fully homomorphic encryption without bootstrapping.md
+++ b/content/References/BGV12 - Leveled fully homomorphic encryption without bootstrapping.md
@@ -1,18 +1,17 @@
 ---
-title: (Leveled) Fully Homomorphic Encryption without Bootstrapping
-URL: https://dl.acm.org/doi/10.1145/2090236.2090262
+title: "BGV12"
+source: https://eprint.iacr.org/2011/277
 authors: Zvika Brakerski, Craig Gentry, Vinod Vaikuntanathan
 venue: ITCS 2012
-publish date: 2012
+published: 2012
 aliases:
   - BGV12
 cryptobib_key: ITCS:BraGenVai12
 ---
 
-# (Leveled) Fully Homomorphic Encryption without Bootstrapping
+# [BGV12] (Leveled) Fully Homomorphic Encryption without Bootstrapping
 
-URL: https://dl.acm.org/doi/10.1145/2090236.2090262
-Authors: Zvika Brakerski, Craig Gentry, Vinod Vaikuntanathan
+**Authors:** Zvika Brakerski, Craig Gentry, Vinod Vaikuntanathan | **Venue:** ITCS 2012 | [Source](https://eprint.iacr.org/2011/277)
 
 ## Abstract
 

--- a/content/References/BGW88 - Completeness theorems for non-cryptographic fault-tolerant distributed computation.md
+++ b/content/References/BGW88 - Completeness theorems for non-cryptographic fault-tolerant distributed computation.md
@@ -6,6 +6,14 @@ venue: STOC 1988
 published: 1988
 aliases:
   - BGW88
+bibtex: |
+  @inproceedings{BGW88,
+    author    = {Michael Ben-Or and Shafi Goldwasser and Avi Wigderson},
+    title     = {Completeness Theorems for Non-Cryptographic Fault-Tolerant Distributed Computation},
+    booktitle = {Proceedings of the 20th Annual ACM Symposium on Theory of Computing (STOC 1988)},
+    pages     = {1--10},
+    year      = {1988}
+  }
 ---
 
 # [BGW88] Completeness Theorems for Non-Cryptographic Fault-Tolerant Distributed Computation

--- a/content/References/BGW88 - Completeness theorems for non-cryptographic fault-tolerant distributed computation.md
+++ b/content/References/BGW88 - Completeness theorems for non-cryptographic fault-tolerant distributed computation.md
@@ -1,17 +1,16 @@
 ---
-title: Completeness Theorems for Non-Cryptographic Fault-Tolerant Distributed Computation
-URL: https://dl.acm.org/doi/10.1145/62212.62213
+title: "BGW88"
+source: https://dl.acm.org/doi/10.1145/62212.62213
 authors: Michael Ben-Or, Shafi Goldwasser, Avi Wigderson
 venue: STOC 1988
-publish date: 1988
+published: 1988
 aliases:
   - BGW88
 ---
 
-# Completeness Theorems for Non-Cryptographic Fault-Tolerant Distributed Computation
+# [BGW88] Completeness Theorems for Non-Cryptographic Fault-Tolerant Distributed Computation
 
-URL: https://dl.acm.org/doi/10.1145/62212.62213
-Authors: Michael Ben-Or, Shafi Goldwasser, Avi Wigderson
+**Authors:** Michael Ben-Or, Shafi Goldwasser, Avi Wigderson | **Venue:** STOC 1988 | [Source](https://dl.acm.org/doi/10.1145/62212.62213)
 
 ## Abstract
 

--- a/content/References/BH26 - How to Steal Oblivious Transfer from Minicrypt.md
+++ b/content/References/BH26 - How to Steal Oblivious Transfer from Minicrypt.md
@@ -8,6 +8,14 @@ aliases:
   - BH26
 tags:
   - ePrint
+bibtex: |
+  @misc{BH26,
+    author       = {Cruz Barnum and David Heath},
+    title        = {How to Steal Oblivious Transfer from Minicrypt},
+    howpublished = {Cryptology ePrint Archive, Paper 2026/113},
+    year         = {2026},
+    url          = {https://eprint.iacr.org/2026/113}
+  }
 ---
 
 # [BH26] How to Steal Oblivious Transfer from Minicrypt

--- a/content/References/BHNZ25 - Separating QMA from QCMA with a Classical Oracle.md
+++ b/content/References/BHNZ25 - Separating QMA from QCMA with a Classical Oracle.md
@@ -8,6 +8,15 @@ aliases:
   - BHNZ25
 tags:
   - STOC
+bibtex: |
+  @misc{BHNZ25,
+    author       = {John Bostanci and Jonas Haferkamp and Chinmay Nirkhe and Mark Zhandry},
+    title        = {Separating {QMA} from {QCMA} with a Classical Oracle},
+    howpublished = {arXiv:2511.09551},
+    note         = {To appear, STOC 2026},
+    year         = {2025},
+    url          = {https://arxiv.org/abs/2511.09551}
+  }
 ---
 
 # [BHNZ25] Separating QMA from QCMA with a Classical Oracle

--- a/content/References/BHV26 - Separating Quantum and Classical Advice with Good Codes.md
+++ b/content/References/BHV26 - Separating Quantum and Classical Advice with Good Codes.md
@@ -8,6 +8,14 @@ aliases:
   - BHV26
 tags:
   - ECCC
+bibtex: |
+  @misc{BHV26,
+    author       = {John Bostanci and Andrew Huang and Vinod Vaikuntanathan},
+    title        = {Separating Quantum and Classical Advice with Good Codes},
+    howpublished = {arXiv:2602.09385},
+    year         = {2026},
+    url          = {https://arxiv.org/abs/2602.09385}
+  }
 ---
 
 # [BHV26] Separating Quantum and Classical Advice with Good Codes

--- a/content/References/BM09 - Merkle Puzzles Are Optimal An O(n2)-Query Attack on Any Key Exchange from a Random Oracle.md
+++ b/content/References/BM09 - Merkle Puzzles Are Optimal An O(n2)-Query Attack on Any Key Exchange from a Random Oracle.md
@@ -1,6 +1,6 @@
 ---
 title: "BM09"
-source: https://link.springer.com/chapter/10.1007/978-3-642-03356-8_22
+source: https://eprint.iacr.org/2008/032
 authors: Boaz Barak, Mohammad Mahmoody-Ghidary
 venue: CRYPTO 2009
 published: 2009-08-19
@@ -12,7 +12,7 @@ tags:
 
 # [BM09] Merkle Puzzles Are Optimal — An O(n²)-Query Attack on Any Key Exchange from a Random Oracle
 
-**Authors:** Boaz Barak, Mohammad Mahmoody-Ghidary | **Venue:** CRYPTO 2009 | [Source](https://link.springer.com/chapter/10.1007/978-3-642-03356-8_22)
+**Authors:** Boaz Barak, Mohammad Mahmoody-Ghidary | **Venue:** CRYPTO 2009 | [Source](https://eprint.iacr.org/2008/032)
 
 ## Abstract
 

--- a/content/References/BM09 - Merkle Puzzles Are Optimal An O(n2)-Query Attack on Any Key Exchange from a Random Oracle.md
+++ b/content/References/BM09 - Merkle Puzzles Are Optimal An O(n2)-Query Attack on Any Key Exchange from a Random Oracle.md
@@ -8,6 +8,18 @@ aliases:
   - BM09
 tags:
   - CRYPTO
+bibtex: |
+  @inproceedings{BM09,
+    author    = {Boaz Barak and Mohammad Mahmoody-Ghidary},
+    title     = {Merkle Puzzles Are Optimal --- An {$O(n^2)$}-Query Attack on Any Key Exchange from a Random Oracle},
+    booktitle = {Advances in Cryptology --- CRYPTO 2009},
+    series    = {Lecture Notes in Computer Science},
+    volume    = {5677},
+    pages     = {374--390},
+    publisher = {Springer},
+    year      = {2009},
+    url       = {https://eprint.iacr.org/2008/032}
+  }
 ---
 
 # [BM09] Merkle Puzzles Are Optimal — An O(n²)-Query Attack on Any Key Exchange from a Random Oracle

--- a/content/References/BM25 - Superposition Detection and QMA with Non-Collapsing Measurements.md
+++ b/content/References/BM25 - Superposition Detection and QMA with Non-Collapsing Measurements.md
@@ -8,6 +8,14 @@ aliases:
   - BM25
 tags:
   - Quantum
+bibtex: |
+  @article{BM25,
+    author  = {Roozbeh Bassirian and Kunal Marwaha},
+    title   = {Superposition Detection and {QMA} with Non-Collapsing Measurements},
+    journal = {Quantum},
+    year    = {2025},
+    url     = {https://arxiv.org/abs/2403.02532}
+  }
 ---
 
 # [BM25] Superposition Detection and QMA with Non-Collapsing Measurements

--- a/content/References/BM88 - Arthur-merlin games A randomized proof system and a hierarchy of complexity classes.md
+++ b/content/References/BM88 - Arthur-merlin games A randomized proof system and a hierarchy of complexity classes.md
@@ -8,6 +8,16 @@ aliases:
   - BM88
 tags:
   - JCSS
+bibtex: |
+  @article{BM88,
+    author  = {L\'{a}szl\'{o} Babai and Shlomo Moran},
+    title   = {Arthur-Merlin Games: A Randomized Proof System, and a Hierarchy of Complexity Classes},
+    journal = {Journal of Computer and System Sciences},
+    volume  = {36},
+    number  = {2},
+    pages   = {254--276},
+    year    = {1988}
+  }
 ---
 
 # [BM88] Arthur-merlin games A randomized proof system and a hierarchy of complexity classes

--- a/content/References/BMZ19 - The Distinction Between Fixed and Random Generators in Group-Based Assumptions.md
+++ b/content/References/BMZ19 - The Distinction Between Fixed and Random Generators in Group-Based Assumptions.md
@@ -1,6 +1,6 @@
 ---
 title: "BMZ19"
-source: https://link.springer.com/chapter/10.1007/978-3-030-26951-7_27
+source: https://eprint.iacr.org/2019/202
 authors: James Bartusek, Fermi Ma, and Mark Zhandry
 venue: CRYPTO 2019
 published: 2019-01-01
@@ -13,7 +13,7 @@ cryptobib_key: C:BarMaZha19
 
 # [BMZ19] The Distinction Between Fixed and Random Generators in Group-Based Assumptions
 
-**Authors:** James Bartusek, Fermi Ma, and Mark Zhandry | **Venue:** CRYPTO 2019 | [Source](https://link.springer.com/chapter/10.1007/978-3-030-26951-7_27)
+**Authors:** James Bartusek, Fermi Ma, and Mark Zhandry | **Venue:** CRYPTO 2019 | [Source](https://eprint.iacr.org/2019/202)
 
 ## Abstract
 

--- a/content/References/BS98 - Collusion-secure fingerprinting for digital data.md
+++ b/content/References/BS98 - Collusion-secure fingerprinting for digital data.md
@@ -8,6 +8,16 @@ aliases:
   - BS98
 tags:
   - IEEE Transactions on Information Theory
+bibtex: |
+  @article{BS98,
+    author  = {Dan Boneh and James Shaw},
+    title   = {Collusion-Secure Fingerprinting for Digital Data},
+    journal = {IEEE Transactions on Information Theory},
+    volume  = {44},
+    number  = {5},
+    pages   = {1897--1905},
+    year    = {1998}
+  }
 ---
 
 # [BS98] Collusion-secure fingerprinting for digital data

--- a/content/References/BW07 - Conjunctive Normal Form Encryption and Attribute Based Encryption.md
+++ b/content/References/BW07 - Conjunctive Normal Form Encryption and Attribute Based Encryption.md
@@ -8,6 +8,18 @@ aliases:
   - BW07
 tags:
   - TCC
+bibtex: |
+  @inproceedings{BW07,
+    author    = {Dan Boneh and Brent Waters},
+    title     = {Conjunctive, Subset, and Range Queries on Encrypted Data},
+    booktitle = {Theory of Cryptography --- TCC 2007},
+    series    = {Lecture Notes in Computer Science},
+    volume    = {4392},
+    pages     = {535--554},
+    publisher = {Springer},
+    year      = {2007},
+    url       = {https://eprint.iacr.org/2006/465}
+  }
 ---
 
 # [BW07] Conjunctive, Subset, and Range Queries on Encrypted Data

--- a/content/References/Bla79 - Safeguarding cryptographic keys.md
+++ b/content/References/Bla79 - Safeguarding cryptographic keys.md
@@ -1,18 +1,17 @@
 ---
-title: Safeguarding Cryptographic Keys
-URL: https://ieeexplore.ieee.org/document/4356614
+title: "Bla79"
+source: https://ieeexplore.ieee.org/document/4356614
 authors: G.R. Blakley
 venue: AFIPS National Computer Conference
-publish date: 1979
+published: 1979
 aliases:
   - Bla79
 cryptobib_key: Blakley79
 ---
 
-# Safeguarding Cryptographic Keys
+# [Bla79] Safeguarding Cryptographic Keys
 
-URL: https://ieeexplore.ieee.org/document/4356614
-Authors: G.R. Blakley
+**Authors:** G.R. Blakley | **Venue:** AFIPS National Computer Conference | [Source](https://ieeexplore.ieee.org/document/4356614)
 
 ## Abstract
 

--- a/content/References/Bra79 - Relativized cryptography.md
+++ b/content/References/Bra79 - Relativized cryptography.md
@@ -9,6 +9,14 @@ aliases:
   - Bra79
 tags:
   - FOCS
+bibtex: |
+  @inproceedings{Bra79,
+    author    = {Gilles Brassard},
+    title     = {Relativized Cryptography},
+    booktitle = {20th Annual Symposium on Foundations of Computer Science (FOCS 1979)},
+    pages     = {383--391},
+    year      = {1979}
+  }
 ---
 
 # [Bra79] Relativized cryptography

--- a/content/References/CCG+94 - The random oracle hypothesis is false.md
+++ b/content/References/CCG+94 - The random oracle hypothesis is false.md
@@ -8,6 +8,16 @@ aliases:
   - CCG+94
 tags:
   - JCSS
+bibtex: |
+  @article{CCG+94,
+    author  = {Richard Chang and Benny Chor and Oded Goldreich and Juris Hartmanis and Johan H{\aa}stad and Desh Ranjan and Pankaj Rohatgi},
+    title   = {The Random Oracle Hypothesis Is False},
+    journal = {Journal of Computer and System Sciences},
+    volume  = {49},
+    number  = {1},
+    pages   = {24--39},
+    year    = {1994}
+  }
 ---
 
 # [CCG+94] The random oracle hypothesis is false

--- a/content/References/CD22 - An efficient key recovery attack on SIDH.md
+++ b/content/References/CD22 - An efficient key recovery attack on SIDH.md
@@ -1,18 +1,17 @@
 ---
-title: An Efficient Key Recovery Attack on SIDH
-URL: https://eprint.iacr.org/2022/975
+title: "CD22"
+source: https://eprint.iacr.org/2022/975
 authors: Wouter Castryck, Thomas Decru
 venue: EUROCRYPT 2023
-publish date: 2022
+published: 2022
 aliases:
   - CD22
 cryptobib_key: EC:CasDec23
 ---
 
-# An Efficient Key Recovery Attack on SIDH
+# [CD22] An Efficient Key Recovery Attack on SIDH
 
-URL: https://eprint.iacr.org/2022/975
-Authors: Wouter Castryck, Thomas Decru
+**Authors:** Wouter Castryck, Thomas Decru | **Venue:** EUROCRYPT 2023 | [Source](https://eprint.iacr.org/2022/975)
 
 ## Abstract
 

--- a/content/References/CDH20 - A Lower Bound for One-Round Oblivious RAM.md
+++ b/content/References/CDH20 - A Lower Bound for One-Round Oblivious RAM.md
@@ -1,9 +1,9 @@
 ---
 title: "CDH20"
-URL: https://eprint.iacr.org/2020/1195
+source: https://eprint.iacr.org/2020/1195
 authors: David Cash, Andrew Drucker, Alexander Hoover
 venue: TCC 2020
-publish date: 2020-06-10
+published: 2020-06-10
 aliases:
   - CDH20
 tags:

--- a/content/References/CG97 - Computationally private information retrieval.md
+++ b/content/References/CG97 - Computationally private information retrieval.md
@@ -9,6 +9,14 @@ aliases:
   - CG97
 tags:
   - STOC
+bibtex: |
+  @inproceedings{CG97,
+    author    = {Benny Chor and Niv Gilboa},
+    title     = {Computationally Private Information Retrieval},
+    booktitle = {Proceedings of the 29th Annual ACM Symposium on Theory of Computing (STOC 1997)},
+    pages     = {304--313},
+    year      = {1997}
+  }
 ---
 
 # [CG97] Computationally private information retrieval

--- a/content/References/CHW26 - The Structured Generic-Group Model.md
+++ b/content/References/CHW26 - The Structured Generic-Group Model.md
@@ -8,6 +8,14 @@ aliases:
   - CHW26
 tags:
   - Eurocrypt
+bibtex: |
+  @misc{CHW26,
+    author       = {Henry Corrigan-Gibbs and Alexandra Henzinger and David J. Wu},
+    title        = {The Structured Generic-Group Model},
+    howpublished = {Cryptology ePrint Archive, Paper 2026/384},
+    year         = {2026},
+    url          = {https://eprint.iacr.org/2026/384}
+  }
 ---
 
 # [CHW26] The Structured Generic-Group Model

--- a/content/References/Can01 - Universally composable security a new paradigm for cryptographic protocols.md
+++ b/content/References/Can01 - Universally composable security a new paradigm for cryptographic protocols.md
@@ -1,6 +1,6 @@
 ---
 title: "Can01"
-source: https://ieeexplore.ieee.org/abstract/document/959888
+source: https://eprint.iacr.org/2000/067
 authors: Ran Canetti
 venue: FOCS 2001, JACM 2020
 published: 2001-06-01
@@ -13,7 +13,7 @@ cryptobib_key: FOCS:Canetti01
 
 # [Can01] Universally composable security: a new paradigm for cryptographic protocols
 
-**Authors:** Ran Canetti | **Venue:** FOCS 2001, JACM 2020 | [Source](https://ieeexplore.ieee.org/abstract/document/959888)
+**Authors:** Ran Canetti | **Venue:** FOCS 2001, JACM 2020 | [Source](https://eprint.iacr.org/2000/067)
 
 ## Abstract
 

--- a/content/References/Cle86 - Limits on the security of coin flips when half the processors are faulty.md
+++ b/content/References/Cle86 - Limits on the security of coin flips when half the processors are faulty.md
@@ -9,6 +9,14 @@ aliases:
   - Cle86
 tags:
   - STOC
+bibtex: |
+  @inproceedings{Cle86,
+    author    = {Richard Cleve},
+    title     = {Limits on the Security of Coin Flips When Half the Processors Are Faulty},
+    booktitle = {Proceedings of the 18th Annual ACM Symposium on Theory of Computing (STOC 1986)},
+    pages     = {364--369},
+    year      = {1986}
+  }
 ---
 
 # [Cle86] Limits on the security of coin flips when half the processors are faulty

--- a/content/References/DLO24 - Breaking RSA Generically Is Equivalent to Factoring, with Preprocessing.md
+++ b/content/References/DLO24 - Breaking RSA Generically Is Equivalent to Factoring, with Preprocessing.md
@@ -1,6 +1,6 @@
 ---
 title: "DLO24"
-source: https://drops.dagstuhl.de/entities/document/10.4230/LIPIcs.ITC.2024.8
+source: https://eprint.iacr.org/2022/1261
 authors: Dana Dachman-Soled, Julian Loss, Adam O'Neill
 venue: ITC 2024
 published: 2024
@@ -13,7 +13,7 @@ cryptobib_key: ITC:DacLosONe24
 
 # [DLO24] Breaking RSA Generically Is Equivalent to Factoring, with Preprocessing
 
-**Authors:** Dana Dachman-Soled, Julian Loss, Adam O'Neill | **Venue:** ITC 2024 | [Source](https://drops.dagstuhl.de/entities/document/10.4230/LIPIcs.ITC.2024.8)
+**Authors:** Dana Dachman-Soled, Julian Loss, Adam O'Neill | **Venue:** ITC 2024 | [Source](https://eprint.iacr.org/2022/1261)
 
 ## Abstract
 

--- a/content/References/Din20 - On the Streaming Indistinguishability of a Random Permutation and a Random Function.md
+++ b/content/References/Din20 - On the Streaming Indistinguishability of a Random Permutation and a Random Function.md
@@ -1,6 +1,6 @@
 ---
 title: "Din20"
-source: https://link.springer.com/chapter/10.1007/978-3-030-45724-2_15
+source: https://eprint.iacr.org/2019/413
 authors: Itai Dinur
 venue: Eurocrypt 2020
 published: 2020-01-01
@@ -14,7 +14,7 @@ cryptobib_key: EC:Dinur20b
 
 # [Din20] On the Streaming Indistinguishability of a Random Permutation and a Random Function
 
-**Authors:** Itai Dinur | **Venue:** Eurocrypt 2020 | [Source](https://link.springer.com/chapter/10.1007/978-3-030-45724-2_15)
+**Authors:** Itai Dinur | **Venue:** Eurocrypt 2020 | [Source](https://eprint.iacr.org/2019/413)
 
 ## Abstract
 

--- a/content/References/GG21 - The Advantage of Truncated Permutations.md
+++ b/content/References/GG21 - The Advantage of Truncated Permutations.md
@@ -8,6 +8,16 @@ aliases:
   - GG21
 tags:
   - Discrete Applied Mathematics
+bibtex: |
+  @article{GG21,
+    author  = {Shoni Gilboa and Shay Gueron},
+    title   = {The Advantage of Truncated Permutations},
+    journal = {Discrete Applied Mathematics},
+    volume  = {294},
+    pages   = {214--223},
+    year    = {2021},
+    url     = {https://arxiv.org/abs/1610.02518}
+  }
 ---
 
 # [GG21] The Advantage of Truncated Permutations

--- a/content/References/GG98 - On the possibility of basing Cryptography on the assumption that P != NP.md
+++ b/content/References/GG98 - On the possibility of basing Cryptography on the assumption that P != NP.md
@@ -8,6 +8,14 @@ aliases:
   - GG98
 tags:
   - preprint
+bibtex: |
+  @misc{GG98,
+    author       = {Oded Goldreich and Shafi Goldwasser},
+    title        = {On the Possibility of Basing Cryptography on the Assumption that {$P \neq NP$}},
+    howpublished = {Cryptology ePrint Archive, Paper 1998/005},
+    year         = {1998},
+    url          = {https://eprint.iacr.org/1998/005}
+  }
 ---
 
 # [GG98] On the possibility of basing Cryptography on the assumption that $P \neq NP$

--- a/content/References/GGHRSW13 - Candidate indistinguishability obfuscation and functional encryption for all circuits.md
+++ b/content/References/GGHRSW13 - Candidate indistinguishability obfuscation and functional encryption for all circuits.md
@@ -1,18 +1,17 @@
 ---
-title: Candidate Indistinguishability Obfuscation and Functional Encryption for All Circuits
-URL: https://eprint.iacr.org/2013/451
+title: "GGHRSW13"
+source: https://eprint.iacr.org/2013/451
 authors: Sanjam Garg, Craig Gentry, Shai Halevi, Mariana Raykova, Amit Sahai, Brent Waters
 venue: FOCS 2013
-publish date: 2013
+published: 2013
 aliases:
   - GGHRSW13
 cryptobib_key: FOCS:GGHRSW13
 ---
 
-# Candidate Indistinguishability Obfuscation and Functional Encryption for All Circuits
+# [GGHRSW13] Candidate Indistinguishability Obfuscation and Functional Encryption for All Circuits
 
-URL: https://eprint.iacr.org/2013/451
-Authors: Sanjam Garg, Craig Gentry, Shai Halevi, Mariana Raykova, Amit Sahai, Brent Waters
+**Authors:** Sanjam Garg, Craig Gentry, Shai Halevi, Mariana Raykova, Amit Sahai, Brent Waters | **Venue:** FOCS 2013 | [Source](https://eprint.iacr.org/2013/451)
 
 ## Abstract
 

--- a/content/References/GIKM00 - Protecting Data Privacy in Private Information Retrieval Scheme.md
+++ b/content/References/GIKM00 - Protecting Data Privacy in Private Information Retrieval Scheme.md
@@ -8,6 +8,16 @@ aliases:
   - GIKM00
 tags:
   - STOC
+bibtex: |
+  @article{GIKM00,
+    author  = {Yael Gertner and Yuval Ishai and Eyal Kushilevitz and Tal Malkin},
+    title   = {Protecting Data Privacy in Private Information Retrieval Schemes},
+    journal = {Journal of Computer and System Sciences},
+    volume  = {60},
+    number  = {3},
+    pages   = {592--629},
+    year    = {2000}
+  }
 ---
 
 # [GIKM00] Protecting Data Privacy in Private Information Retrieval Scheme

--- a/content/References/GK96 - On the Composition of Zero-Knowledge Proof Systems.md
+++ b/content/References/GK96 - On the Composition of Zero-Knowledge Proof Systems.md
@@ -8,6 +8,16 @@ aliases:
   - GK96
 tags:
   - SIAMJC
+bibtex: |
+  @article{GK96,
+    author  = {Oded Goldreich and Hugo Krawczyk},
+    title   = {On the Composition of Zero-Knowledge Proof Systems},
+    journal = {SIAM Journal on Computing},
+    volume  = {25},
+    number  = {1},
+    pages   = {169--192},
+    year    = {1996}
+  }
 ---
 
 # [GK96] On the Composition of Zero-Knowledge Proof Systems

--- a/content/References/GM84 - Probabilistic encryption.md
+++ b/content/References/GM84 - Probabilistic encryption.md
@@ -1,18 +1,17 @@
 ---
-title: Probabilistic Encryption
-URL: https://www.sciencedirect.com/science/article/pii/0022000084900709
+title: "GM84"
+source: https://www.sciencedirect.com/science/article/pii/0022000084900709
 authors: Shafi Goldwasser, Silvio Micali
 venue: Journal of Computer and System Sciences
-publish date: 1984
+published: 1984
 aliases:
   - GM84
 cryptobib_key: GolMic84
 ---
 
-# Probabilistic Encryption
+# [GM84] Probabilistic Encryption
 
-URL: https://www.sciencedirect.com/science/article/pii/0022000084900709
-Authors: Shafi Goldwasser, Silvio Micali
+**Authors:** Shafi Goldwasser, Silvio Micali | **Venue:** Journal of Computer and System Sciences | [Source](https://www.sciencedirect.com/science/article/pii/0022000084900709)
 
 ## Abstract
 

--- a/content/References/GMR85 - The knowledge complexity of interactive proof-systems.md
+++ b/content/References/GMR85 - The knowledge complexity of interactive proof-systems.md
@@ -1,18 +1,17 @@
 ---
-title: The Knowledge Complexity of Interactive Proof-Systems
-URL: https://dl.acm.org/doi/10.1145/22145.22178
+title: "GMR85"
+source: https://dl.acm.org/doi/10.1145/22145.22178
 authors: Shafi Goldwasser, Silvio Micali, Charles Rackoff
 venue: STOC 1985 / SIAM Journal on Computing, 1989
-publish date: 1985
+published: 1985
 aliases:
   - GMR85
 cryptobib_key: GolMicRac89
 ---
 
-# The Knowledge Complexity of Interactive Proof-Systems
+# [GMR85] The Knowledge Complexity of Interactive Proof-Systems
 
-URL: https://dl.acm.org/doi/10.1145/22145.22178
-Authors: Shafi Goldwasser, Silvio Micali, Charles Rackoff
+**Authors:** Shafi Goldwasser, Silvio Micali, Charles Rackoff | **Venue:** STOC 1985 / SIAM Journal on Computing, 1989 | [Source](https://dl.acm.org/doi/10.1145/22145.22178)
 
 ## Abstract
 

--- a/content/References/GMW87 - How to play ANY mental game.md
+++ b/content/References/GMW87 - How to play ANY mental game.md
@@ -1,19 +1,27 @@
 ---
-title: "GM87"
+title: "GMW87"
 source: https://dl.acm.org/doi/10.1145/28395.28420
 authors: Oded Goldreich, Silvio Micali, Avi Wigderson
-venue: preprint
+venue: STOC 1987
 published: 1987-01-01
 created: 2025-03-01
 aliases:
-  - GM87
+  - GMW87
 tags:
-  - preprint
+  - STOC
+bibtex: |
+  @inproceedings{GMW87,
+    author    = {Oded Goldreich and Silvio Micali and Avi Wigderson},
+    title     = {How to Play {ANY} Mental Game or A Completeness Theorem for Protocols with Honest Majority},
+    booktitle = {Proceedings of the 19th Annual ACM Symposium on Theory of Computing (STOC 1987)},
+    pages     = {218--229},
+    year      = {1987}
+  }
 ---
 
-# [GM87] How to play ANY mental game
+# [GMW87] How to play ANY mental game
 
-**Authors:** Oded Goldreich, Silvio Micali, Avi Wigderson | **Venue:** preprint | [Source](https://dl.acm.org/doi/10.1145/28395.28420)
+**Authors:** Oded Goldreich, Silvio Micali, Avi Wigderson | **Venue:** STOC 1987 | [Source](https://dl.acm.org/doi/10.1145/28395.28420)
 
 ## Abstract
 

--- a/content/References/GO96 - Software protection and simulation on oblivious RAMs.md
+++ b/content/References/GO96 - Software protection and simulation on oblivious RAMs.md
@@ -1,9 +1,9 @@
 ---
 title: "GO96"
-URL: https://dl.acm.org/doi/abs/10.1145/233551.233553
+source: https://dl.acm.org/doi/abs/10.1145/233551.233553
 authors: Oded Goldreich, Rafail Ostrovsky
 venue: Journal of the ACM 1996
-publish date: 05/01/2025
+published: 05/01/2025
 aliases:
   - GO96
 tags:

--- a/content/References/GPV08 - Trapdoors for hard lattices and new cryptographic constructions.md
+++ b/content/References/GPV08 - Trapdoors for hard lattices and new cryptographic constructions.md
@@ -1,6 +1,6 @@
 ---
 title: "GPV08"
-source: https://dl.acm.org/doi/10.1145/1374376.1374407
+source: https://eprint.iacr.org/2007/432
 authors: Craig Gentry, Chris Peikert, Vinod Vaikuntanathan
 venue: STOC 2008
 published: 2008-05-01
@@ -13,7 +13,7 @@ cryptobib_key: STOC:GenPeiVai08
 
 # [GPV08] Trapdoors for Hard Lattices and New Cryptographic Constructions
 
-**Authors:** Craig Gentry, Chris Peikert, Vinod Vaikuntanathan | **Venue:** STOC 2008 | [Source](https://dl.acm.org/doi/10.1145/1374376.1374407)
+**Authors:** Craig Gentry, Chris Peikert, Vinod Vaikuntanathan | **Venue:** STOC 2008 | [Source](https://eprint.iacr.org/2007/432)
 
 ## Abstract
 

--- a/content/References/Gen09 - Fully homomorphic encryption using ideal lattices.md
+++ b/content/References/Gen09 - Fully homomorphic encryption using ideal lattices.md
@@ -1,18 +1,17 @@
 ---
-title: Fully Homomorphic Encryption Using Ideal Lattices
-URL: https://dl.acm.org/doi/10.1145/1536414.1536440
+title: "Gen09"
+source: https://dl.acm.org/doi/10.1145/1536414.1536440
 authors: Craig Gentry
 venue: STOC 2009
-publish date: 2009
+published: 2009
 aliases:
   - Gen09
 cryptobib_key: STOC:Gentry09
 ---
 
-# Fully Homomorphic Encryption Using Ideal Lattices
+# [Gen09] Fully Homomorphic Encryption Using Ideal Lattices
 
-URL: https://dl.acm.org/doi/10.1145/1536414.1536440
-Authors: Craig Gentry
+**Authors:** Craig Gentry | **Venue:** STOC 2009 | [Source](https://dl.acm.org/doi/10.1145/1536414.1536440)
 
 ## Abstract
 

--- a/content/References/Grover96 - A fast quantum mechanical algorithm for database search.md
+++ b/content/References/Grover96 - A fast quantum mechanical algorithm for database search.md
@@ -1,10 +1,16 @@
 ---
+source: https://arxiv.org/abs/quant-ph/9605043
 aliases:
   - Grover96
-title: "Grover96 - A fast quantum mechanical algorithm for database search"
+title: "Grover96"
 cryptobib_key: STOC:Grover96
+authors: Lov K. Grover
+venue: STOC 1996
+published: 1996-01-01
 ---
 
-Lov K. Grover. "A fast quantum mechanical algorithm for database search." In _Proceedings of the 28th Annual ACM Symposium on Theory of Computing (STOC 1996)_, pp. 212–219. ACM, 1996.
+# [Grover96] A fast quantum mechanical algorithm for database search
+
+**Authors:** Lov K. Grover | **Venue:** STOC 1996 | [Source](https://arxiv.org/abs/quant-ph/9605043)
 
 Presented the quantum algorithm for unstructured search that finds a marked element among $N$ items in $O(\sqrt{N})$ quantum queries, compared to $\Omega(N)$ classically. This is optimal for quantum query complexity. In cryptographic terms, Grover's algorithm gives a generic quadratic speedup against symmetric-key primitives, implying that $n$-bit security requires $2n$-bit keys in the post-quantum setting (e.g., AES-256 for 128-bit post-quantum security).

--- a/content/References/HKKS19 - Stronger Lower Bounds for Online ORAM.md
+++ b/content/References/HKKS19 - Stronger Lower Bounds for Online ORAM.md
@@ -1,6 +1,6 @@
 ---
 title: "HKKS19"
-source: https://link.springer.com/chapter/10.1007/978-3-030-36033-7_10
+source: https://arxiv.org/abs/1903.03385
 authors: Pavel Hubáček, Michal Koucký, Karel Král, Veronika Slívová
 venue: TCC 2019
 published: 2019-11-22
@@ -14,7 +14,7 @@ cryptobib_key: TCC:HKKS19
 
 # [HKKS19] Stronger Lower Bounds for Online ORAM
 
-**Authors:** Pavel Hubáček, Michal Koucký, Karel Král, Veronika Slívová | **Venue:** TCC 2019 | [Source](https://link.springer.com/chapter/10.1007/978-3-030-36033-7_10)
+**Authors:** Pavel Hubáček, Michal Koucký, Karel Král, Veronika Slívová | **Venue:** TCC 2019 | [Source](https://arxiv.org/abs/1903.03385)
 
 ## Abstract
 

--- a/content/References/Imp95 - A personal view of average-case complexity.md
+++ b/content/References/Imp95 - A personal view of average-case complexity.md
@@ -9,6 +9,14 @@ aliases:
   - Impagliazzo's Five Worlds
 tags:
   - Complexity
+bibtex: |
+  @inproceedings{Imp95,
+    author    = {Russell Impagliazzo},
+    title     = {A Personal View of Average-Case Complexity},
+    booktitle = {Proceedings of the 10th Annual Structure in Complexity Theory Conference},
+    pages     = {134--147},
+    year      = {1995}
+  }
 ---
 
 # [Imp95] A personal view of average-case complexity

--- a/content/References/JDF11 - Towards quantum-resistant cryptosystems from supersingular elliptic curve isogenies.md
+++ b/content/References/JDF11 - Towards quantum-resistant cryptosystems from supersingular elliptic curve isogenies.md
@@ -1,18 +1,17 @@
 ---
-title: Towards Quantum-Resistant Cryptosystems from Supersingular Elliptic Curve Isogenies
-URL: https://link.springer.com/chapter/10.1007/978-3-642-25405-5_2
+title: "JDF11"
+source: https://eprint.iacr.org/2011/506
 authors: David Jao, Luca De Feo
 venue: PQCrypto 2011
-publish date: 2011
+published: 2011
 aliases:
   - JDF11
 cryptobib_key: PQCRYPTO:JaoDeF11
 ---
 
-# Towards Quantum-Resistant Cryptosystems from Supersingular Elliptic Curve Isogenies
+# [JDF11] Towards Quantum-Resistant Cryptosystems from Supersingular Elliptic Curve Isogenies
 
-URL: https://link.springer.com/chapter/10.1007/978-3-642-25405-5_2
-Authors: David Jao, Luca De Feo
+**Authors:** David Jao, Luca De Feo | **Venue:** PQCrypto 2011 | [Source](https://eprint.iacr.org/2011/506)
 
 ## Abstract
 

--- a/content/References/JLS21 - Indistinguishability obfuscation from well-founded assumptions.md
+++ b/content/References/JLS21 - Indistinguishability obfuscation from well-founded assumptions.md
@@ -1,18 +1,17 @@
 ---
-title: Indistinguishability Obfuscation from Well-Founded Assumptions
-URL: https://dl.acm.org/doi/10.1145/3406325.3451093
+title: "JLS21"
+source: https://eprint.iacr.org/2020/1003
 authors: Aayush Jain, Huijia Lin, Amit Sahai
 venue: STOC 2021
-publish date: 2021
+published: 2021
 aliases:
   - JLS21
 cryptobib_key: STOC:JaiLinSah21
 ---
 
-# Indistinguishability Obfuscation from Well-Founded Assumptions
+# [JLS21] Indistinguishability Obfuscation from Well-Founded Assumptions
 
-URL: https://dl.acm.org/doi/10.1145/3406325.3451093
-Authors: Aayush Jain, Huijia Lin, Amit Sahai
+**Authors:** Aayush Jain, Huijia Lin, Amit Sahai | **Venue:** STOC 2021 | [Source](https://eprint.iacr.org/2020/1003)
 
 ## Abstract
 

--- a/content/References/KZG10 - Constant-size commitments to polynomials and their applications.md
+++ b/content/References/KZG10 - Constant-size commitments to polynomials and their applications.md
@@ -1,10 +1,16 @@
 ---
+source: https://link.springer.com/chapter/10.1007/978-3-642-17373-8_11
 aliases:
   - KZG10
-title: "KZG10 - Constant-size commitments to polynomials and their applications"
+title: "KZG10"
 cryptobib_key: AC:KatZavGol10
+authors: Aniket Kate, Gregory M. Zaverucha, Ian Goldberg
+venue: Asiacrypt 2010
+published: 2010-01-01
 ---
 
-Aniket Kate, Gregory M. Zaverucha, and Ian Goldberg. "Constant-size commitments to polynomials and their applications." In _Advances in Cryptology — ASIACRYPT 2010_, Lecture Notes in Computer Science, vol. 6477, pp. 177–194. Springer, 2010.
+# [KZG10] Constant-size commitments to polynomials and their applications
+
+**Authors:** Aniket Kate, Gregory M. Zaverucha, Ian Goldberg | **Venue:** Asiacrypt 2010 | [Source](https://link.springer.com/chapter/10.1007/978-3-642-17373-8_11)
 
 Introduced the KZG polynomial commitment scheme, which allows a prover to commit to a polynomial $f \in \FF_p[X]$ with a single group element and later prove evaluations $f(z) = y$ with a single group element proof (O(1) size). Security relies on the $q$-Strong Diffie-Hellman assumption in a bilinear group and requires a structured reference string (trusted setup) of the form $(g, g^\tau, g^{\tau^2}, \ldots, g^{\tau^d})$ for secret $\tau$. KZG is the polynomial commitment underlying most practical SNARKs, including Plonk and Marlin, and is used in Ethereum's KZG ceremony (EIP-4844).

--- a/content/References/LN18 - Yes, There is an Oblivious RAM Lower Bound!.md
+++ b/content/References/LN18 - Yes, There is an Oblivious RAM Lower Bound!.md
@@ -1,9 +1,9 @@
 ---
 title: "LN18"
-URL: https://eprint.iacr.org/2018/423
+source: https://eprint.iacr.org/2018/423
 authors: Kasper Green Larsen, Jesper Buus Nielsen
 venue: CRYPTO 2018
-publish date: 2018-05-18
+published: 2018-05-18
 aliases:
   - LN18
 tags:

--- a/content/References/LPR10 - On ideal lattices and learning with errors over rings.md
+++ b/content/References/LPR10 - On ideal lattices and learning with errors over rings.md
@@ -1,10 +1,16 @@
 ---
+source: https://eprint.iacr.org/2012/230
 aliases:
   - LPR10
-title: "LPR10 - On ideal lattices and learning with errors over rings"
+title: "LPR10"
 cryptobib_key: EC:LyuPeiReg10
+authors: Vadim Lyubashevsky, Chris Peikert, Oded Regev
+venue: Eurocrypt 2010
+published: 2010-01-01
 ---
 
-Vadim Lyubashevsky, Chris Peikert, and Oded Regev. "On ideal lattices and learning with errors over rings." In _Advances in Cryptology — EUROCRYPT 2010_, Lecture Notes in Computer Science, vol. 6110, pp. 1–23. Springer, 2010.
+# [LPR10] On ideal lattices and learning with errors over rings
+
+**Authors:** Vadim Lyubashevsky, Chris Peikert, Oded Regev | **Venue:** Eurocrypt 2010 | [Source](https://eprint.iacr.org/2012/230)
 
 Introduced Ring LWE (RLWE), which restricts LWE samples to a polynomial ring $R_q = \ZZ_q[x]/\langle\Phi_n(x)\rangle$ (typically the $n$-th cyclotomic ring). This yields $O(n \log n)$-size keys (vs. $O(n^2)$ for plain LWE) and admits fast NTT-based arithmetic. The paper also gives a quantum worst-case to average-case reduction from ideal lattice problems (Ideal-SVP) to Ring LWE.

--- a/content/References/LS15 - Worst-case to average-case reductions for module lattices.md
+++ b/content/References/LS15 - Worst-case to average-case reductions for module lattices.md
@@ -1,10 +1,16 @@
 ---
+source: https://eprint.iacr.org/2012/090
 aliases:
   - LS15
-title: "LS15 - Worst-case to average-case reductions for module lattices"
+title: "LS15"
 cryptobib_key: DCC:LanSte15
+authors: Adeline Langlois, Damien Stehlé
+venue: Designs, Codes and Cryptography
+published: 2015-01-01
 ---
 
-Adeline Langlois and Damien Stehlé. "Worst-case to average-case reductions for module lattices." _Designs, Codes and Cryptography_, 75(3):565–599, 2015.
+# [LS15] Worst-case to average-case reductions for module lattices
+
+**Authors:** Adeline Langlois, Damien Stehlé | **Venue:** Designs, Codes and Cryptography | [Source](https://eprint.iacr.org/2012/090)
 
 Introduced Module LWE (MLWE), which generalizes Ring LWE by considering rank-$k$ modules over a polynomial ring $R_q$. When $k = 1$ this recovers Ring LWE; when $k = n$ this recovers plain LWE. The module structure interpolates between the two extremes, yielding a flexible parameter trade-off between efficiency and security assumptions. Kyber (ML-KEM) and Dilithium (ML-DSA), the NIST post-quantum standards, are based on Module LWE.

--- a/content/References/LS26 - Symmetric Attribute-Based Encryption from Minimal Hardness Assumptions.md
+++ b/content/References/LS26 - Symmetric Attribute-Based Encryption from Minimal Hardness Assumptions.md
@@ -1,5 +1,5 @@
 ---
-title: Symmetric Attribute-Based Encryption from Minimal Hardness Assumptions
+title: "LS26"
 aliases:
   - LS26
 authors:

--- a/content/References/Mau05 - Abstract Models of Computation in Cryptography.md
+++ b/content/References/Mau05 - Abstract Models of Computation in Cryptography.md
@@ -8,6 +8,17 @@ aliases:
   - Mau05
 tags:
   - IMA
+bibtex: |
+  @inproceedings{Mau05,
+    author    = {Ueli Maurer},
+    title     = {Abstract Models of Computation in Cryptography},
+    booktitle = {Cryptography and Coding --- 10th IMA International Conference},
+    series    = {Lecture Notes in Computer Science},
+    volume    = {3796},
+    pages     = {1--12},
+    publisher = {Springer},
+    year      = {2005}
+  }
 ---
 
 # [Mau05] Abstract Models of Computation in Cryptography

--- a/content/References/NN23 - A Distribution Testing Oracle Separation between QMA and QCMA.md
+++ b/content/References/NN23 - A Distribution Testing Oracle Separation between QMA and QCMA.md
@@ -8,6 +8,17 @@ aliases:
   - NN23
 tags:
   - CCC
+bibtex: |
+  @inproceedings{NN23,
+    author    = {Anand Natarajan and Chinmay Nirkhe},
+    title     = {A Distribution Testing Oracle Separating {QMA} and {QCMA}},
+    booktitle = {38th Computational Complexity Conference (CCC 2023)},
+    series    = {LIPIcs},
+    volume    = {264},
+    pages     = {22:1--22:27},
+    year      = {2023},
+    url       = {https://arxiv.org/abs/2210.15380}
+  }
 ---
 
 # [NN23] A Distribution Testing Oracle Separation between QMA and QCMA

--- a/content/References/Naor91 - Bit commitment using pseudorandomness.md
+++ b/content/References/Naor91 - Bit commitment using pseudorandomness.md
@@ -1,18 +1,17 @@
 ---
-title: Bit Commitment Using Pseudorandomness
-URL: https://link.springer.com/article/10.1007/BF00191386
+title: "Naor91"
+source: https://link.springer.com/article/10.1007/BF00191386
 authors: Moni Naor
 venue: Journal of Cryptology
-publish date: 1991
+published: 1991
 aliases:
   - Naor91
 cryptobib_key: JC:Naor91
 ---
 
-# Bit Commitment Using Pseudorandomness
+# [Naor91] Bit Commitment Using Pseudorandomness
 
-URL: https://link.springer.com/article/10.1007/BF00191386
-Authors: Moni Naor
+**Authors:** Moni Naor | **Venue:** Journal of Cryptology | [Source](https://link.springer.com/article/10.1007/BF00191386)
 
 ## Abstract
 

--- a/content/References/Ost91 - One-way functions, hard on average problems, and statistical zero-knowledge proofs.md
+++ b/content/References/Ost91 - One-way functions, hard on average problems, and statistical zero-knowledge proofs.md
@@ -3,12 +3,20 @@ title: "Ost91"
 source: https://ieeexplore.ieee.org/document/160253
 authors: Rafail Ostrovsky
 venue: IEEE Complexity 1991
-published: 1991-06-31
+published: 1991-06-30
 created: 2025-02-20
 aliases:
   - Ost91
 tags:
   - Complexity
+bibtex: |
+  @inproceedings{Ost91,
+    author    = {Rafail Ostrovsky},
+    title     = {One-Way Functions, Hard on Average Problems, and Statistical Zero-Knowledge Proofs},
+    booktitle = {Proceedings of the 6th Annual Structure in Complexity Theory Conference},
+    pages     = {133--138},
+    year      = {1991}
+  }
 ---
 
 # [Ost91] One-way functions, hard on average problems, and statistical zero-knowledge proofs

--- a/content/References/Pai99 - Public-key cryptosystems based on composite degree residuosity classes.md
+++ b/content/References/Pai99 - Public-key cryptosystems based on composite degree residuosity classes.md
@@ -1,18 +1,17 @@
 ---
-title: Public-Key Cryptosystems Based on Composite Degree Residuosity Classes
-URL: https://link.springer.com/chapter/10.1007/3-540-48910-X_16
+title: "Pai99"
+source: https://link.springer.com/chapter/10.1007/3-540-48910-X_16
 authors: Pascal Paillier
 venue: EUROCRYPT 1999
-publish date: 1999
+published: 1999
 aliases:
   - Pai99
 cryptobib_key: EC:Paillier99
 ---
 
-# Public-Key Cryptosystems Based on Composite Degree Residuosity Classes
+# [Pai99] Public-Key Cryptosystems Based on Composite Degree Residuosity Classes
 
-URL: https://link.springer.com/chapter/10.1007/3-540-48910-X_16
-Authors: Pascal Paillier
+**Authors:** Pascal Paillier | **Venue:** EUROCRYPT 1999 | [Source](https://link.springer.com/chapter/10.1007/3-540-48910-X_16)
 
 ## Abstract
 

--- a/content/References/Pap94 - On the complexity of the parity argument and other inefficient proofs of existence.md
+++ b/content/References/Pap94 - On the complexity of the parity argument and other inefficient proofs of existence.md
@@ -9,6 +9,16 @@ tags:
   - JCSS
 aliases:
   - Pap94
+bibtex: |
+  @article{Pap94,
+    author  = {Christos H. Papadimitriou},
+    title   = {On the Complexity of the Parity Argument and Other Inefficient Proofs of Existence},
+    journal = {Journal of Computer and System Sciences},
+    volume  = {48},
+    number  = {3},
+    pages   = {498--532},
+    year    = {1994}
+  }
 ---
 
 # [Pap94] On the complexity of the parity argument and other inefficient proofs of existence

--- a/content/References/Reg05 - On Lattices, Learning with Errors, Random Linear Codes, and Cryptography.md
+++ b/content/References/Reg05 - On Lattices, Learning with Errors, Random Linear Codes, and Cryptography.md
@@ -1,6 +1,6 @@
 ---
 title: "Reg05"
-source: https://dl.acm.org/doi/10.1145/1060590.1060603
+source: https://arxiv.org/abs/2401.03703
 authors: Oded Regev
 venue: STOC 2005
 published: 2005-05-01
@@ -13,7 +13,7 @@ cryptobib_key: STOC:Regev05
 
 # [Reg05] On Lattices, Learning with Errors, Random Linear Codes, and Cryptography
 
-**Authors:** Oded Regev | **Venue:** STOC 2005 | [Source](https://dl.acm.org/doi/10.1145/1060590.1060603)
+**Authors:** Oded Regev | **Venue:** STOC 2005 | [Source](https://arxiv.org/abs/2401.03703)
 
 ## Abstract
 

--- a/content/References/SS11 - Making NTRU as secure as worst-case problems over ideal lattices.md
+++ b/content/References/SS11 - Making NTRU as secure as worst-case problems over ideal lattices.md
@@ -1,6 +1,6 @@
 ---
 title: "SS11"
-source: https://link.springer.com/chapter/10.1007/978-3-642-20465-4_4
+source: https://eprint.iacr.org/2013/004
 authors: Damien Stehlé, Ron Steinfeld
 venue: Advances in Cryptology — EUROCRYPT 2011
 published: 2011-05-15
@@ -13,7 +13,7 @@ cryptobib_key: EC:SteSte11
 
 # [SS11] Making NTRU as secure as worst-case problems over ideal lattices
 
-**Authors:** Damien Stehlé, Ron Steinfeld | **Venue:** EUROCRYPT 2011 | [Source](https://link.springer.com/chapter/10.1007/978-3-642-20465-4_4)
+**Authors:** Damien Stehlé, Ron Steinfeld | **Venue:** EUROCRYPT 2011 | [Source](https://eprint.iacr.org/2013/004)
 
 ## Abstract
 

--- a/content/References/Sch91 - Efficient signature generation by smart cards.md
+++ b/content/References/Sch91 - Efficient signature generation by smart cards.md
@@ -1,10 +1,16 @@
 ---
+source: https://link.springer.com/article/10.1007/BF00196725
 aliases:
   - Sch91
-title: "Sch91 - Efficient signature generation by smart cards"
+title: "Sch91"
 cryptobib_key: JC:Schnorr91
+authors: Claus-Peter Schnorr
+venue: Journal of Cryptology
+published: 1991-01-01
 ---
 
-Claus-Peter Schnorr. "Efficient signature generation by smart cards." _Journal of Cryptology_, 4(3):161–174, 1991.
+# [Sch91] Efficient signature generation by smart cards
+
+**Authors:** Claus-Peter Schnorr | **Venue:** Journal of Cryptology | [Source](https://link.springer.com/article/10.1007/BF00196725)
 
 Introduced the Schnorr identification protocol and signature scheme. The identification protocol is a three-message sigma protocol (commit–challenge–response) for proving knowledge of a discrete logarithm, and is honest-verifier zero-knowledge under the discrete logarithm assumption. Applying the Fiat-Shamir transform (heuristically in the random oracle model) yields Schnorr signatures, which are EUF-CMA secure under the discrete logarithm assumption in the ROM. Schnorr signatures are the basis for EdDSA (Ed25519) and play a central role in the Schnorr multi-signature and threshold signature literature.

--- a/content/References/Sha79 - How to share a secret.md
+++ b/content/References/Sha79 - How to share a secret.md
@@ -1,18 +1,17 @@
 ---
-title: How to Share a Secret
-URL: https://dl.acm.org/doi/10.1145/359168.359176
+title: "Sha79"
+source: https://dl.acm.org/doi/10.1145/359168.359176
 authors: Adi Shamir
 venue: Communications of the ACM
-publish date: 1979
+published: 1979
 aliases:
   - Sha79
 cryptobib_key: EC:Mignotte82
 ---
 
-# How to Share a Secret
+# [Sha79] How to Share a Secret
 
-URL: https://dl.acm.org/doi/10.1145/359168.359176
-Authors: Adi Shamir
+**Authors:** Adi Shamir | **Venue:** Communications of the ACM | [Source](https://dl.acm.org/doi/10.1145/359168.359176)
 
 ## Abstract
 

--- a/content/References/Shor97 - Polynomial-time algorithms for prime factorization and discrete logarithms on a quantum computer.md
+++ b/content/References/Shor97 - Polynomial-time algorithms for prime factorization and discrete logarithms on a quantum computer.md
@@ -8,6 +8,16 @@ aliases:
   - Shor97
 tags:
   - SIAMJC
+bibtex: |
+  @article{Shor97,
+    author  = {Peter W. Shor},
+    title   = {Polynomial-Time Algorithms for Prime Factorization and Discrete Logarithms on a Quantum Computer},
+    journal = {SIAM Journal on Computing},
+    volume  = {26},
+    number  = {5},
+    pages   = {1484--1509},
+    year    = {1997}
+  }
 ---
 
 # [Shor97] Polynomial-time algorithms for prime factorization and discrete logarithms on a quantum computer

--- a/content/References/Wat11 - Ciphertext-Policy Attribute-Based Encryption from Subset Cover.md
+++ b/content/References/Wat11 - Ciphertext-Policy Attribute-Based Encryption from Subset Cover.md
@@ -8,6 +8,18 @@ aliases:
   - Wat11
 tags:
   - PKC
+bibtex: |
+  @inproceedings{Wat11,
+    author    = {Brent Waters},
+    title     = {Ciphertext-Policy Attribute-Based Encryption: An Expressive, Efficient, and Provably Secure Realization},
+    booktitle = {Public-Key Cryptography --- PKC 2011},
+    series    = {Lecture Notes in Computer Science},
+    volume    = {6571},
+    pages     = {53--70},
+    publisher = {Springer},
+    year      = {2011},
+    url       = {https://eprint.iacr.org/2008/290}
+  }
 ---
 
 # [Wat11] Ciphertext-Policy Attribute-Based Encryption: An Expressive, Efficient, and Provably Secure Realization

--- a/content/References/Wil25 - Simulating Time in Square-Root Space.md
+++ b/content/References/Wil25 - Simulating Time in Square-Root Space.md
@@ -8,6 +8,14 @@ aliases:
   - Wil25
 tags:
   - STOC
+bibtex: |
+  @inproceedings{Wil25,
+    author    = {R. Ryan Williams},
+    title     = {Simulating Time in Square-Root Space},
+    booktitle = {Proceedings of the 57th Annual ACM Symposium on Theory of Computing (STOC 2025)},
+    year      = {2025},
+    url       = {https://arxiv.org/abs/2502.17779}
+  }
 ---
 
 # [Wil25] Simulating Time in Square-Root Space

--- a/content/References/Wil25 - Simulating Time in Square-Root Space.md
+++ b/content/References/Wil25 - Simulating Time in Square-Root Space.md
@@ -1,6 +1,6 @@
 ---
 title: "Wil25"
-source: https://eccc.weizmann.ac.il/report/2025/017/
+source: https://arxiv.org/abs/2502.17779
 authors: Ryan Williams
 venue: STOC 2025
 published: 2025-02-24
@@ -12,7 +12,7 @@ tags:
 
 # [Wil25] Simulating Time in Square-Root Space
 
-**Authors:** Ryan Williams | **Venue:** STOC 2025 | [Source](https://eccc.weizmann.ac.il/report/2025/017/)
+**Authors:** Ryan Williams | **Venue:** STOC 2025 | [Source](https://arxiv.org/abs/2502.17779)
 
 ## Abstract
 

--- a/content/References/Yao82 - Protocols for secure computations.md
+++ b/content/References/Yao82 - Protocols for secure computations.md
@@ -1,17 +1,16 @@
 ---
-title: Protocols for Secure Computations
-URL: https://ieeexplore.ieee.org/document/4568388
+title: "Yao82"
+source: https://ieeexplore.ieee.org/document/4568388
 authors: Andrew C. Yao
 venue: FOCS 1982
-publish date: 1982
+published: 1982
 aliases:
   - Yao82
 ---
 
-# Protocols for Secure Computations
+# [Yao82] Protocols for Secure Computations
 
-URL: https://ieeexplore.ieee.org/document/4568388
-Authors: Andrew C. Yao
+**Authors:** Andrew C. Yao | **Venue:** FOCS 1982 | [Source](https://ieeexplore.ieee.org/document/4568388)
 
 ## Abstract
 

--- a/content/References/Yao82 - Protocols for secure computations.md
+++ b/content/References/Yao82 - Protocols for secure computations.md
@@ -6,6 +6,14 @@ venue: FOCS 1982
 published: 1982
 aliases:
   - Yao82
+bibtex: |
+  @inproceedings{Yao82,
+    author    = {Andrew C. Yao},
+    title     = {Protocols for Secure Computations},
+    booktitle = {23rd Annual Symposium on Foundations of Computer Science (FOCS 1982)},
+    pages     = {160--164},
+    year      = {1982}
+  }
 ---
 
 # [Yao82] Protocols for Secure Computations

--- a/content/References/Zal97 - Grover's quantum searching algorithm is optimal.md
+++ b/content/References/Zal97 - Grover's quantum searching algorithm is optimal.md
@@ -8,6 +8,17 @@ aliases:
   - Zal97
 tags:
   - preprint
+bibtex: |
+  @article{Zal97,
+    author  = {Christof Zalka},
+    title   = {Grover's Quantum Searching Algorithm Is Optimal},
+    journal = {Physical Review A},
+    volume  = {60},
+    number  = {4},
+    pages   = {2746--2751},
+    year    = {1999},
+    url     = {https://arxiv.org/abs/quant-ph/9711070}
+  }
 ---
 
 # [Zal97] Grover's quantum searching algorithm is optimal


### PR DESCRIPTION
- Rename non-standard YAML fields: `URL:` → `source:`, `publish date:` → `published:` (18 files)
- Standardize `title:` to citation key format (was full paper title in 16 files)
- Reformat body of old-template files to `# [KEY] Title` + `**Authors:** | **Venue:** | [Source]()` style
- Add missing `authors:`, `venue:`, `published:` frontmatter to 6 stub files (BBHR18, Grover96, KZG10, LPR10, LS15, Sch91)
- Add source URLs to files that were missing them
- Update source URLs to eprint.iacr.org/arxiv.org where available (BGV12, BMZ19, BM09, Can01, Din20, DLO24, GPV08, HKKS19, JDF11, JLS21, Reg05, SS11, Wil25)

https://claude.ai/code/session_01JfmDSNhow9EdCbcmqhDaXs